### PR TITLE
Update repo URL and encourage uv for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,16 @@ Markdown-based slide creation tool for research talks. Git-friendly, AI-drivable
 
 ## Install
 
+Colloquium uses [uv](https://docs.astral.sh/uv/) for fast, reliable Python package management.
+
 ```bash
-pip install git+https://github.com/Interconnects-AI/colloquium.git
+uv pip install git+https://github.com/natolambert/colloquium.git
 ```
 
 Or for development:
 
 ```bash
-git clone https://github.com/Interconnects-AI/colloquium.git
+git clone https://github.com/natolambert/colloquium.git
 cd colloquium
 uv pip install -e .
 ```

--- a/examples/hello/hello.html
+++ b/examples/hello/hello.html
@@ -1074,7 +1074,7 @@ deck.build(&quot;output/&quot;)
 <section class="slide slide--title" data-index="22">
 <h1>Thank You</h1>
 <div class="slide-content"><p>Questions?</p>
-<p>github.com/interconnects-ai/colloquium</p>
+<p>github.com/natolambert/colloquium</p>
 </div>
 <div class="colloquium-footer"><div class="colloquium-footer-left"><img class="colloquium-footer-logo" src="logo.png" alt="" style="height: 24px"></div><div class="colloquium-footer-center"></div><div class="colloquium-footer-right"><span class="colloquium-counter">23 / 25</span></div></div>
 </section>

--- a/examples/hello/hello.md
+++ b/examples/hello/hello.md
@@ -333,4 +333,4 @@ The reward model is trained with the Bradley-Terry preference model, where $y_w$
 
 Questions?
 
-github.com/interconnects-ai/colloquium
+github.com/natolambert/colloquium

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ dependencies = [
 colloquium = "colloquium.cli:main"
 
 [project.urls]
-Homepage = "https://github.com/interconnects-ai/colloquium"
-Repository = "https://github.com/interconnects-ai/colloquium"
+Homepage = "https://github.com/natolambert/colloquium"
+Repository = "https://github.com/natolambert/colloquium"
 
 [tool.hatch.build.targets.wheel]
 packages = ["colloquium"]


### PR DESCRIPTION
## Summary
- Updates all GitHub URLs from `Interconnects-AI/colloquium` to `natolambert/colloquium` (README, pyproject.toml, example deck + rebuilt HTML)
- Adds a note in the install section recommending [uv](https://docs.astral.sh/uv/) for package management

## Test plan
- [ ] Verify `uv pip install git+https://github.com/natolambert/colloquium.git` works
- [ ] Confirm all links in README point to the correct repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)