### PR TITLE
Add fragment-based animations for incremental slide reveal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ One line per PR for easy copy into GitHub releases.
 
 ## [Unreleased]
 
+- Add fragment-based animations: `<!-- animate: bullets|blocks -->` and `<!-- step -->` for incremental reveal ([#25](https://github.com/natolambert/colloquium/pull/25))
 - Normalize BibTeX braces in citations and references ([#19](https://github.com/natolambert/colloquium/pull/19))
 - Add `colloquium capture` command for per-slide PNG export via Ghostscript ([#17](https://github.com/natolambert/colloquium/pull/17))
 - Fix PDF export clipping for printed equations and captioned figures ([#18](https://github.com/natolambert/colloquium/pull/18))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ One line per PR for easy copy into GitHub releases.
 - Upgrade locked pytest to 9.0.3 and Pygments to 2.20.0 to fix CVE-2025-71176 and CVE-2026-4539 ([#30](https://github.com/natolambert/colloquium/pull/30))
 - Upgrade locked lxml to 6.1.0 to fix CVE-2026-41066 (XXE in iterparse/ETCompatXMLParser) ([#31](https://github.com/natolambert/colloquium/pull/31))
 - Add a built-in iframe element for embedding external or local HTML content ([#32](https://github.com/natolambert/colloquium/pull/32))
+- Add fragment-based animations: `<!-- animate: bullets|blocks -->` and `<!-- step -->` for incremental reveal ([#25](https://github.com/natolambert/colloquium/pull/25))
 
 ## [0.2.1] - 2026-03-25
 

--- a/colloquium/build.py
+++ b/colloquium/build.py
@@ -92,7 +92,7 @@ def _render_figure_captions(rendered: str, md: MarkdownIt) -> str:
 # ===== Fragment processing (incremental reveal) =====
 
 _STEP_MARKER_RE = re.compile(r"\s*<!--\s*step\s*-->\s*")
-_FRAGMENT_CLASS_RE = re.compile(r'class="fragment"')
+_FRAGMENT_CLASS_RE = re.compile(r'class="fragment\b([^"]*)"')
 _FRAGMENT_BLOCK_TAGS = frozenset(
     ("p", "ul", "ol", "pre", "blockquote", "table", "figure")
 )
@@ -176,8 +176,64 @@ def _apply_auto_animate(html: str, animate_type: str) -> str:
     return html
 
 
+def _wrap_non_fragment_blocks(html: str) -> str:
+    """Wrap top-level block elements that don't already contain fragments.
+
+    Used for step groups where auto-animate (bullets/items) has fragmentized
+    ``<li>`` elements but left other block content (paragraphs, etc.) without
+    a fragment wrapper, which would make them visible before the step click.
+    """
+    open_re = re.compile(
+        r"<(" + "|".join(_FRAGMENT_BLOCK_TAGS) + r")[\s>]"
+    )
+    close_re = re.compile(
+        r"</(" + "|".join(_FRAGMENT_BLOCK_TAGS) + r")>"
+    )
+
+    lines = html.split("\n")
+    blocks: list[str] = []
+    current: list[str] = []
+    depth = 0
+
+    for line in lines:
+        opens = sum(1 for _ in open_re.finditer(line))
+        closes = sum(1 for _ in close_re.finditer(line))
+
+        if depth == 0 and opens == 0 and not current:
+            if line.strip():
+                blocks.append(line)
+            continue
+
+        current.append(line)
+        depth += opens - closes
+
+        if depth <= 0:
+            depth = 0
+            block_html = "\n".join(current)
+            if block_html.strip():
+                if 'class="fragment' in block_html:
+                    # Block already has fragment elements — leave as-is
+                    blocks.append(block_html)
+                else:
+                    blocks.append(f'<div class="fragment">{block_html}</div>')
+            current = []
+
+    if current:
+        block_html = "\n".join(current)
+        if block_html.strip():
+            if 'class="fragment' in block_html:
+                blocks.append(block_html)
+            else:
+                blocks.append(f'<div class="fragment">{block_html}</div>')
+
+    return "\n".join(blocks)
+
+
 def _number_fragments(html: str) -> tuple[str, int]:
     """Add sequential ``data-fragment-index`` to all fragment elements.
+
+    Handles both ``class="fragment"`` and ``class="fragment extra-cls"``
+    (elements with additional classes).
 
     Returns *(processed_html, total_fragment_count)*.
     """
@@ -186,7 +242,8 @@ def _number_fragments(html: str) -> tuple[str, int]:
     def _replace(m: re.Match) -> str:
         nonlocal count
         count += 1
-        return f'class="fragment" data-fragment-index="{count}"'
+        extra = m.group(1)  # "" or " extra-class ..."
+        return f'class="fragment{extra}" data-fragment-index="{count}"'
 
     result = _FRAGMENT_CLASS_RE.sub(_replace, html)
     return result, count
@@ -221,8 +278,12 @@ def _process_fragments(
             chunk = _apply_auto_animate(chunk, animate_type)
 
         if is_fragment:
-            # If auto-animate already added fragments inside, don't double-wrap
-            if 'class="fragment"' in chunk:
+            has_inner = 'class="fragment' in chunk
+            if has_inner:
+                # Auto-animate added fragments to some elements (e.g. <li>).
+                # Wrap remaining non-fragment blocks so they are also hidden
+                # until the step is reached (e.g. a <p> after a <ul>).
+                chunk = _wrap_non_fragment_blocks(chunk)
                 parts.append(chunk)
             else:
                 parts.append(f'<div class="fragment">{chunk}</div>')

--- a/colloquium/build.py
+++ b/colloquium/build.py
@@ -89,6 +89,150 @@ def _render_figure_captions(rendered: str, md: MarkdownIt) -> str:
     return _STANDALONE_IMAGE_PARAGRAPH_RE.sub(_replace, rendered)
 
 
+# ===== Fragment processing (incremental reveal) =====
+
+_STEP_MARKER_RE = re.compile(r"\s*<!--\s*step\s*-->\s*")
+_FRAGMENT_CLASS_RE = re.compile(r'class="fragment"')
+_FRAGMENT_BLOCK_TAGS = frozenset(
+    ("p", "ul", "ol", "pre", "blockquote", "table", "figure")
+)
+
+
+def _process_step_markers(html: str) -> list[tuple[str, bool]]:
+    """Split rendered HTML at ``<!-- step -->`` markers.
+
+    Returns a list of *(html_chunk, is_fragment)* tuples.
+    The first chunk (before any step marker) has *is_fragment=False*.
+    """
+    parts = _STEP_MARKER_RE.split(html)
+    result = []
+    for i, part in enumerate(parts):
+        part = part.strip()
+        if part:
+            result.append((part, i > 0))
+    return result
+
+
+def _wrap_blocks_as_fragments(html: str) -> str:
+    """Wrap each top-level block element as a fragment div.
+
+    Uses depth tracking so nested block elements (e.g. ``<blockquote>``
+    containing ``<p>``) are treated as a single top-level block.
+    """
+    open_re = re.compile(
+        r"<(" + "|".join(_FRAGMENT_BLOCK_TAGS) + r")[\s>]"
+    )
+    close_re = re.compile(
+        r"</(" + "|".join(_FRAGMENT_BLOCK_TAGS) + r")>"
+    )
+
+    lines = html.split("\n")
+    blocks: list[str] = []
+    current: list[str] = []
+    depth = 0
+
+    for line in lines:
+        opens = sum(1 for _ in open_re.finditer(line))
+        closes = sum(1 for _ in close_re.finditer(line))
+
+        if depth == 0 and opens == 0 and not current:
+            # Non-block content outside any block — pass through
+            if line.strip():
+                blocks.append(line)
+            continue
+
+        current.append(line)
+        depth += opens - closes
+
+        if depth <= 0:
+            depth = 0
+            block_html = "\n".join(current)
+            if block_html.strip():
+                blocks.append(f'<div class="fragment">{block_html}</div>')
+            current = []
+
+    if current:
+        block_html = "\n".join(current)
+        if block_html.strip():
+            blocks.append(f'<div class="fragment">{block_html}</div>')
+
+    return "\n".join(blocks)
+
+
+def _apply_auto_animate(html: str, animate_type: str) -> str:
+    """Add ``class="fragment"`` to elements based on *animate_type*.
+
+    * ``bullets`` / ``items`` — each ``<li>`` becomes a fragment.
+    * ``blocks`` — each top-level block element becomes a fragment.
+    """
+    if animate_type in ("bullets", "items"):
+        # Handle <li class="..."> first (prepend fragment to existing class)
+        html = re.sub(r'<li class="', '<li class="fragment ', html)
+        # Then handle plain <li> (add fragment class)
+        html = re.sub(r"<li>", '<li class="fragment">', html)
+        return html
+    if animate_type == "blocks":
+        return _wrap_blocks_as_fragments(html)
+    return html
+
+
+def _number_fragments(html: str) -> tuple[str, int]:
+    """Add sequential ``data-fragment-index`` to all fragment elements.
+
+    Returns *(processed_html, total_fragment_count)*.
+    """
+    count = 0
+
+    def _replace(m: re.Match) -> str:
+        nonlocal count
+        count += 1
+        return f'class="fragment" data-fragment-index="{count}"'
+
+    result = _FRAGMENT_CLASS_RE.sub(_replace, html)
+    return result, count
+
+
+def _process_fragments(
+    html: str, animate_type: str | None,
+) -> tuple[str, int]:
+    """Process step markers and auto-animate to produce fragment markup.
+
+    Returns *(processed_html, fragment_count)*.
+    """
+    if not animate_type and "<!-- step" not in html:
+        return html, 0
+
+    # Split at step markers
+    groups = _process_step_markers(html)
+    if not groups:
+        return html, 0
+
+    # No step markers — single group, just apply auto-animate
+    if len(groups) == 1 and not groups[0][1]:
+        if animate_type:
+            result = _apply_auto_animate(groups[0][0], animate_type)
+            return _number_fragments(result)
+        return html, 0
+
+    # Multiple groups (step markers present)
+    parts = []
+    for chunk, is_fragment in groups:
+        if animate_type:
+            chunk = _apply_auto_animate(chunk, animate_type)
+
+        if is_fragment:
+            # If auto-animate already added fragments inside, don't double-wrap
+            if 'class="fragment"' in chunk:
+                parts.append(chunk)
+            else:
+                parts.append(f'<div class="fragment">{chunk}</div>')
+        else:
+            parts.append(chunk)
+
+    result = "\n".join(parts)
+    return _number_fragments(result)
+
+
 # ===== Citation processing =====
 
 _CITATION_RE = re.compile(r'\[@([\w:.\-]+(?:\s*;\s*@[\w:.\-]+)*)\]')
@@ -810,6 +954,7 @@ def _build_slide_html(
         bib_entries = {}
     if cited_keys is None:
         cited_keys = []
+    fragment_count = 0
 
     # CSS classes
     classes = ["slide", f"slide--{slide.layout}"]
@@ -841,10 +986,12 @@ def _build_slide_html(
             inline_footnote_side,
         )
 
+    animate_type = slide.metadata.get("animate")
     if slide_content:
         figure_captions = _slide_uses_figure_captions(slide.classes, deck_figure_captions)
         if has_rows:
             rendered = _build_rows_html(slide_content, md, figure_captions=figure_captions)
+            rendered, fragment_count = _process_fragments(rendered, animate_type)
             rows_spec = _extract_grid_spec(slide.classes, "rows-")
             rows_style = _grid_template_style(rows_spec or "", "rows")
             content_style_attr = f' style="{rows_style}"' if rows_style else ""
@@ -860,6 +1007,7 @@ def _build_slide_html(
                 content_classes.append("colloquium-grid")
                 content_style = _grid_template_style(cols_spec or "", "columns")
                 rendered = _split_columns_from_rendered(rendered)
+            rendered, fragment_count = _process_fragments(rendered, animate_type)
             content_style_attr = f' style="{content_style}"' if content_style else ""
             parts.append(f'<div class="{" ".join(content_classes)}"{content_style_attr}>{rendered}</div>')
 
@@ -901,7 +1049,8 @@ def _build_slide_html(
 
     inner = "\n".join(parts)
 
-    return f'<section class="{class_str}"{slide_style_attr} data-index="{index}">\n{inner}\n</section>'
+    fragment_attr = f' data-fragment-count="{fragment_count}"' if fragment_count > 0 else ""
+    return f'<section class="{class_str}"{slide_style_attr} data-index="{index}"{fragment_attr}>\n{inner}\n</section>'
 
 
 # HTML template — uses $-style substitution

--- a/colloquium/build.py
+++ b/colloquium/build.py
@@ -113,11 +113,16 @@ def _process_step_markers(html: str) -> list[tuple[str, bool]]:
     return result
 
 
-def _wrap_blocks_as_fragments(html: str) -> str:
+def _wrap_blocks_as_fragments(
+    html: str, preserve_column_markers: bool = False,
+) -> str:
     """Wrap each top-level block element as a fragment div.
 
     Uses depth tracking so nested block elements (e.g. ``<blockquote>``
     containing ``<p>``) are treated as a single top-level block.
+
+    When *preserve_column_markers* is True, ``<p>|||</p>`` markers are
+    passed through unwrapped so that column splitting can find them later.
     """
     open_re = re.compile(
         r"<(" + "|".join(_FRAGMENT_BLOCK_TAGS) + r")[\s>]"
@@ -147,8 +152,12 @@ def _wrap_blocks_as_fragments(html: str) -> str:
         if depth <= 0:
             depth = 0
             block_html = "\n".join(current)
-            if block_html.strip():
-                blocks.append(f'<div class="fragment">{block_html}</div>')
+            stripped = block_html.strip()
+            if stripped:
+                if preserve_column_markers and stripped == "<p>|||</p>":
+                    blocks.append(block_html)
+                else:
+                    blocks.append(f'<div class="fragment">{block_html}</div>')
             current = []
 
     if current:
@@ -177,11 +186,18 @@ def _apply_auto_animate(html: str, animate_type: str) -> str:
 
 
 def _wrap_non_fragment_blocks(html: str) -> str:
-    """Wrap top-level block elements that don't already contain fragments.
+    """Wrap top-level block elements that aren't already fully fragmentized.
 
     Used for step groups where auto-animate (bullets/items) has fragmentized
-    ``<li>`` elements but left other block content (paragraphs, etc.) without
-    a fragment wrapper, which would make them visible before the step click.
+    ``<li>`` elements but left other block content (paragraphs, blockquotes,
+    etc.) without a fragment wrapper.
+
+    Skip rules:
+    * ``<div class="fragment ...">`` — already a fragment wrapper.
+    * ``<ul>``/``<ol>`` where every ``<li>`` has ``class="fragment"`` — the
+      list is fully animated, wrapping it would add a redundant empty-list
+      reveal step.
+    * Everything else is wrapped so it stays hidden until the step click.
     """
     open_re = re.compile(
         r"<(" + "|".join(_FRAGMENT_BLOCK_TAGS) + r")[\s>]"
@@ -194,6 +210,22 @@ def _wrap_non_fragment_blocks(html: str) -> str:
     blocks: list[str] = []
     current: list[str] = []
     depth = 0
+
+    def _emit_block(block_html: str) -> None:
+        stripped = block_html.strip()
+        if not stripped:
+            return
+        # Already a fragment wrapper div — skip
+        if stripped.startswith('<div class="fragment'):
+            blocks.append(block_html)
+            return
+        # Fully-animated list (all <li> are fragments) — skip
+        is_list = stripped.startswith(("<ul", "<ol"))
+        if is_list and "<li>" not in block_html and 'class="fragment' in block_html:
+            blocks.append(block_html)
+            return
+        # Wrap everything else
+        blocks.append(f'<div class="fragment">{block_html}</div>')
 
     for line in lines:
         opens = sum(1 for _ in open_re.finditer(line))
@@ -209,22 +241,11 @@ def _wrap_non_fragment_blocks(html: str) -> str:
 
         if depth <= 0:
             depth = 0
-            block_html = "\n".join(current)
-            if block_html.strip():
-                if 'class="fragment' in block_html:
-                    # Block already has fragment elements — leave as-is
-                    blocks.append(block_html)
-                else:
-                    blocks.append(f'<div class="fragment">{block_html}</div>')
+            _emit_block("\n".join(current))
             current = []
 
     if current:
-        block_html = "\n".join(current)
-        if block_html.strip():
-            if 'class="fragment' in block_html:
-                blocks.append(block_html)
-            else:
-                blocks.append(f'<div class="fragment">{block_html}</div>')
+        _emit_block("\n".join(current))
 
     return "\n".join(blocks)
 
@@ -254,9 +275,17 @@ def _process_fragments(
 ) -> tuple[str, int]:
     """Process step markers and auto-animate to produce fragment markup.
 
+    *animate_type* should be ``"bullets"``/``"items"`` or ``None``.
+    ``"blocks"`` mode is applied earlier in the pipeline (before
+    column/row splitting) so it should not be passed here.
+
+    Pre-existing ``class="fragment"`` elements (e.g. from an earlier
+    blocks-wrapping pass) are numbered even when *animate_type* is None.
+
     Returns *(processed_html, fragment_count)*.
     """
-    if not animate_type and "<!-- step" not in html:
+    has_existing = 'class="fragment' in html
+    if not animate_type and "<!-- step" not in html and not has_existing:
         return html, 0
 
     # Split at step markers
@@ -269,6 +298,9 @@ def _process_fragments(
         if animate_type:
             result = _apply_auto_animate(groups[0][0], animate_type)
             return _number_fragments(result)
+        # Number any pre-existing fragments (e.g. from blocks wrapping)
+        if has_existing:
+            return _number_fragments(html)
         return html, 0
 
     # Multiple groups (step markers present)
@@ -280,9 +312,9 @@ def _process_fragments(
         if is_fragment:
             has_inner = 'class="fragment' in chunk
             if has_inner:
-                # Auto-animate added fragments to some elements (e.g. <li>).
-                # Wrap remaining non-fragment blocks so they are also hidden
-                # until the step is reached (e.g. a <p> after a <ul>).
+                # Some elements are already fragments (auto-animate or
+                # pre-existing blocks wrapping).  Wrap any remaining
+                # non-fragment blocks so they stay hidden until the step.
                 chunk = _wrap_non_fragment_blocks(chunk)
                 parts.append(chunk)
             else:
@@ -977,7 +1009,10 @@ def _write_text_atomic(output_path: str, text: str) -> None:
     tmp_path.replace(output)
 
 
-def _build_rows_html(content: str, md: MarkdownIt, figure_captions: bool = False) -> str:
+def _build_rows_html(
+    content: str, md: MarkdownIt, figure_captions: bool = False,
+    animate_type: str | None = None,
+) -> str:
     """Build a row-based slide body with optional nested columns in each row."""
     row_blocks = [block.strip() for block in _ROW_SPLIT_RE.split(content) if block.strip()]
     rows_html = []
@@ -994,7 +1029,13 @@ def _build_rows_html(content: str, md: MarkdownIt, figure_captions: bool = False
         rendered = _render_markdown(block.strip(), md)
         if figure_captions:
             rendered = _render_figure_captions(rendered, md)
-        if any(cls.startswith("cols-") for cls in row_classes):
+        # Apply blocks wrapping per-row BEFORE column splitting
+        has_row_cols = any(cls.startswith("cols-") for cls in row_classes)
+        if animate_type == "blocks":
+            rendered = _wrap_blocks_as_fragments(
+                rendered, preserve_column_markers=has_row_cols,
+            )
+        if has_row_cols:
             rendered = _split_columns_from_rendered(rendered)
 
         style_attr = f' style="{row_style}"' if row_style else ""
@@ -1048,11 +1089,18 @@ def _build_slide_html(
         )
 
     animate_type = slide.metadata.get("animate")
+    # blocks wrapping runs before column/row splitting (it targets raw
+    # block-level elements which get obscured by wrapper divs); bullets
+    # and step markers run after splitting and are passed to _process_fragments.
+    frag_animate = animate_type if animate_type in ("bullets", "items") else None
     if slide_content:
         figure_captions = _slide_uses_figure_captions(slide.classes, deck_figure_captions)
         if has_rows:
-            rendered = _build_rows_html(slide_content, md, figure_captions=figure_captions)
-            rendered, fragment_count = _process_fragments(rendered, animate_type)
+            rendered = _build_rows_html(
+                slide_content, md, figure_captions=figure_captions,
+                animate_type=animate_type,
+            )
+            rendered, fragment_count = _process_fragments(rendered, frag_animate)
             rows_spec = _extract_grid_spec(slide.classes, "rows-")
             rows_style = _grid_template_style(rows_spec or "", "rows")
             content_style_attr = f' style="{rows_style}"' if rows_style else ""
@@ -1061,6 +1109,11 @@ def _build_slide_html(
             rendered = _render_markdown(slide_content, md)
             if figure_captions:
                 rendered = _render_figure_captions(rendered, md)
+            # Apply blocks wrapping before column splitting
+            if animate_type == "blocks":
+                rendered = _wrap_blocks_as_fragments(
+                    rendered, preserve_column_markers=has_columns,
+                )
             content_classes = ["slide-content"]
             content_style = ""
             if has_columns:
@@ -1068,7 +1121,7 @@ def _build_slide_html(
                 content_classes.append("colloquium-grid")
                 content_style = _grid_template_style(cols_spec or "", "columns")
                 rendered = _split_columns_from_rendered(rendered)
-            rendered, fragment_count = _process_fragments(rendered, animate_type)
+            rendered, fragment_count = _process_fragments(rendered, frag_animate)
             content_style_attr = f' style="{content_style}"' if content_style else ""
             parts.append(f'<div class="{" ".join(content_classes)}"{content_style_attr}>{rendered}</div>')
 

--- a/colloquium/build.py
+++ b/colloquium/build.py
@@ -92,10 +92,22 @@ def _render_figure_captions(rendered: str, md: MarkdownIt) -> str:
 # ===== Fragment processing (incremental reveal) =====
 
 _STEP_MARKER_RE = re.compile(r"\s*<!--\s*step\s*-->\s*")
-_FRAGMENT_CLASS_RE = re.compile(r'class="fragment\b([^"]*)"')
+_CLASS_ATTR_RE = re.compile(r'\sclass=(["\'])(.*?)\1')
+_LI_TAG_RE = re.compile(r"<li\b([^>]*)>")
+_GENERATED_FRAGMENT_RE = re.compile(r'\sdata-colloquium-fragment="1"')
 _FRAGMENT_BLOCK_TAGS = frozenset(
     ("p", "ul", "ol", "pre", "blockquote", "table", "figure")
 )
+
+
+def _wrap_fragment_html(content: str) -> str:
+    """Wrap *content* in a generated fragment container."""
+    return f'<div class="fragment" data-colloquium-fragment="1">{content}</div>'
+
+
+def _contains_generated_fragments(html: str) -> bool:
+    """Return True when *html* contains generated fragment markers."""
+    return _GENERATED_FRAGMENT_RE.search(html) is not None
 
 
 def _process_step_markers(html: str) -> list[tuple[str, bool]]:
@@ -157,13 +169,13 @@ def _wrap_blocks_as_fragments(
                 if preserve_column_markers and stripped == "<p>|||</p>":
                     blocks.append(block_html)
                 else:
-                    blocks.append(f'<div class="fragment">{block_html}</div>')
+                    blocks.append(_wrap_fragment_html(block_html))
             current = []
 
     if current:
         block_html = "\n".join(current)
         if block_html.strip():
-            blocks.append(f'<div class="fragment">{block_html}</div>')
+            blocks.append(_wrap_fragment_html(block_html))
 
     return "\n".join(blocks)
 
@@ -175,10 +187,24 @@ def _apply_auto_animate(html: str, animate_type: str) -> str:
     * ``blocks`` — each top-level block element becomes a fragment.
     """
     if animate_type in ("bullets", "items"):
-        # Handle <li class="..."> first (prepend fragment to existing class)
-        html = re.sub(r'<li class="', '<li class="fragment ', html)
-        # Then handle plain <li> (add fragment class)
-        html = re.sub(r"<li>", '<li class="fragment">', html)
+        def _fragmentize(match: re.Match[str]) -> str:
+            attrs = match.group(1)
+            class_match = _CLASS_ATTR_RE.search(attrs)
+            if class_match:
+                classes = class_match.group(2).split()
+                classes = ["fragment", *(cls for cls in classes if cls != "fragment")]
+                attrs = _CLASS_ATTR_RE.sub(
+                    f' class="{" ".join(classes)}"',
+                    attrs,
+                    count=1,
+                )
+            else:
+                attrs = f'{attrs} class="fragment"'
+            if not _contains_generated_fragments(attrs):
+                attrs = f'{attrs} data-colloquium-fragment="1"'
+            return f"<li{attrs}>"
+
+        html = _LI_TAG_RE.sub(_fragmentize, html)
         return html
     if animate_type == "blocks":
         return _wrap_blocks_as_fragments(html)
@@ -216,16 +242,16 @@ def _wrap_non_fragment_blocks(html: str) -> str:
         if not stripped:
             return
         # Already a fragment wrapper div — skip
-        if stripped.startswith('<div class="fragment'):
+        if stripped.startswith('<div class="fragment" data-colloquium-fragment="1">'):
             blocks.append(block_html)
             return
         # Fully-animated list (all <li> are fragments) — skip
         is_list = stripped.startswith(("<ul", "<ol"))
-        if is_list and "<li>" not in block_html and 'class="fragment' in block_html:
+        if is_list and "<li>" not in block_html and _contains_generated_fragments(block_html):
             blocks.append(block_html)
             return
         # Wrap everything else
-        blocks.append(f'<div class="fragment">{block_html}</div>')
+        blocks.append(_wrap_fragment_html(block_html))
 
     for line in lines:
         opens = sum(1 for _ in open_re.finditer(line))
@@ -260,13 +286,12 @@ def _number_fragments(html: str) -> tuple[str, int]:
     """
     count = 0
 
-    def _replace(m: re.Match) -> str:
+    def _replace(m: re.Match[str]) -> str:
         nonlocal count
         count += 1
-        extra = m.group(1)  # "" or " extra-class ..."
-        return f'class="fragment{extra}" data-fragment-index="{count}"'
+        return f' data-fragment-index="{count}"'
 
-    result = _FRAGMENT_CLASS_RE.sub(_replace, html)
+    result = _GENERATED_FRAGMENT_RE.sub(_replace, html)
     return result, count
 
 
@@ -284,7 +309,7 @@ def _process_fragments(
 
     Returns *(processed_html, fragment_count)*.
     """
-    has_existing = 'class="fragment' in html
+    has_existing = _contains_generated_fragments(html)
     if not animate_type and "<!-- step" not in html and not has_existing:
         return html, 0
 
@@ -310,7 +335,7 @@ def _process_fragments(
             chunk = _apply_auto_animate(chunk, animate_type)
 
         if is_fragment:
-            has_inner = 'class="fragment' in chunk
+            has_inner = _contains_generated_fragments(chunk)
             if has_inner:
                 # Some elements are already fragments (auto-animate or
                 # pre-existing blocks wrapping).  Wrap any remaining
@@ -318,7 +343,7 @@ def _process_fragments(
                 chunk = _wrap_non_fragment_blocks(chunk)
                 parts.append(chunk)
             else:
-                parts.append(f'<div class="fragment">{chunk}</div>')
+                parts.append(_wrap_fragment_html(chunk))
         else:
             parts.append(chunk)
 

--- a/colloquium/build.py
+++ b/colloquium/build.py
@@ -96,7 +96,21 @@ _CLASS_ATTR_RE = re.compile(r'\sclass=(["\'])(.*?)\1')
 _LI_TAG_RE = re.compile(r"<li\b([^>]*)>")
 _GENERATED_FRAGMENT_RE = re.compile(r'\sdata-colloquium-fragment="1"')
 _FRAGMENT_BLOCK_TAGS = frozenset(
-    ("p", "ul", "ol", "pre", "blockquote", "table", "figure")
+    (
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "p",
+        "ul",
+        "ol",
+        "pre",
+        "blockquote",
+        "table",
+        "figure",
+    )
 )
 
 

--- a/colloquium/build.py
+++ b/colloquium/build.py
@@ -295,38 +295,31 @@ def _number_fragments(html: str) -> tuple[str, int]:
     return result, count
 
 
-def _process_fragments(
-    html: str, animate_type: str | None,
-) -> tuple[str, int]:
-    """Process step markers and auto-animate to produce fragment markup.
+def _prepare_fragments(html: str, animate_type: str | None) -> str:
+    """Process step markers and auto-animate without assigning indices.
 
     *animate_type* should be ``"bullets"``/``"items"`` or ``None``.
     ``"blocks"`` mode is applied earlier in the pipeline (before
     column/row splitting) so it should not be passed here.
 
-    Pre-existing ``class="fragment"`` elements (e.g. from an earlier
-    blocks-wrapping pass) are numbered even when *animate_type* is None.
-
-    Returns *(processed_html, fragment_count)*.
+    Pre-existing generated fragment markers (e.g. from an earlier
+    blocks-wrapping pass) are preserved for a later whole-slide numbering
+    pass.
     """
     has_existing = _contains_generated_fragments(html)
     if not animate_type and "<!-- step" not in html and not has_existing:
-        return html, 0
+        return html
 
     # Split at step markers
     groups = _process_step_markers(html)
     if not groups:
-        return html, 0
+        return html
 
     # No step markers — single group, just apply auto-animate
     if len(groups) == 1 and not groups[0][1]:
         if animate_type:
-            result = _apply_auto_animate(groups[0][0], animate_type)
-            return _number_fragments(result)
-        # Number any pre-existing fragments (e.g. from blocks wrapping)
-        if has_existing:
-            return _number_fragments(html)
-        return html, 0
+            return _apply_auto_animate(groups[0][0], animate_type)
+        return html
 
     # Multiple groups (step markers present)
     parts = []
@@ -348,6 +341,17 @@ def _process_fragments(
             parts.append(chunk)
 
     result = "\n".join(parts)
+    return result
+
+
+def _process_fragments(
+    html: str, animate_type: str | None,
+) -> tuple[str, int]:
+    """Process fragments and assign sequential ``data-fragment-index`` values.
+
+    Returns *(processed_html, fragment_count)*.
+    """
+    result = _prepare_fragments(html, animate_type)
     return _number_fragments(result)
 
 
@@ -987,6 +991,15 @@ def _split_columns_from_rendered(rendered: str) -> str:
     return "".join(f'<div class="col">{p.strip()}</div>' for p in col_parts)
 
 
+def _build_columns_html(rendered: str, animate_type: str | None) -> str:
+    """Build column wrappers after processing fragments inside each column."""
+    col_parts = re.split(r"<p>\|\|\|</p>", rendered)
+    return "".join(
+        f'<div class="col">{_prepare_fragments(part.strip(), animate_type)}</div>'
+        for part in col_parts
+    )
+
+
 def _extract_grid_spec(classes: list[str], prefix: str) -> str | None:
     """Return the first grid spec found for a class prefix such as cols- or rows-."""
     for cls in classes:
@@ -1039,6 +1052,7 @@ def _build_rows_html(
     animate_type: str | None = None,
 ) -> str:
     """Build a row-based slide body with optional nested columns in each row."""
+    frag_animate = animate_type if animate_type in ("bullets", "items") else None
     row_blocks = [block.strip() for block in _ROW_SPLIT_RE.split(content) if block.strip()]
     rows_html = []
     for block in row_blocks:
@@ -1061,7 +1075,9 @@ def _build_rows_html(
                 rendered, preserve_column_markers=has_row_cols,
             )
         if has_row_cols:
-            rendered = _split_columns_from_rendered(rendered)
+            rendered = _build_columns_html(rendered, frag_animate)
+        else:
+            rendered = _prepare_fragments(rendered, frag_animate)
 
         style_attr = f' style="{row_style}"' if row_style else ""
         rows_html.append(f'<div class="{" ".join(row_classes)}"{style_attr}>{rendered}</div>')
@@ -1116,7 +1132,7 @@ def _build_slide_html(
     animate_type = slide.metadata.get("animate")
     # blocks wrapping runs before column/row splitting (it targets raw
     # block-level elements which get obscured by wrapper divs); bullets
-    # and step markers run after splitting and are passed to _process_fragments.
+    # and step markers run after splitting, inside each layout container.
     frag_animate = animate_type if animate_type in ("bullets", "items") else None
     if slide_content:
         figure_captions = _slide_uses_figure_captions(slide.classes, deck_figure_captions)
@@ -1125,7 +1141,7 @@ def _build_slide_html(
                 slide_content, md, figure_captions=figure_captions,
                 animate_type=animate_type,
             )
-            rendered, fragment_count = _process_fragments(rendered, frag_animate)
+            rendered, fragment_count = _number_fragments(rendered)
             rows_spec = _extract_grid_spec(slide.classes, "rows-")
             rows_style = _grid_template_style(rows_spec or "", "rows")
             content_style_attr = f' style="{rows_style}"' if rows_style else ""
@@ -1145,8 +1161,10 @@ def _build_slide_html(
                 cols_spec = _extract_grid_spec(slide.classes, "cols-")
                 content_classes.append("colloquium-grid")
                 content_style = _grid_template_style(cols_spec or "", "columns")
-                rendered = _split_columns_from_rendered(rendered)
-            rendered, fragment_count = _process_fragments(rendered, frag_animate)
+                rendered = _build_columns_html(rendered, frag_animate)
+                rendered, fragment_count = _number_fragments(rendered)
+            else:
+                rendered, fragment_count = _process_fragments(rendered, frag_animate)
             content_style_attr = f' style="{content_style}"' if content_style else ""
             parts.append(f'<div class="{" ".join(content_classes)}"{content_style_attr}>{rendered}</div>')
 

--- a/colloquium/parse.py
+++ b/colloquium/parse.py
@@ -12,7 +12,7 @@ from colloquium.slide import Slide
 
 # Directive patterns: <!-- key: value -->
 _DIRECTIVE_RE = re.compile(
-    r"<!--\s*(layout|class|style|notes|title|align|valign|columns|rows|padding|size|cite|cite-left|cite-right|footnote|footnote-right|footnotes|img-align|img-valign|img-fill|img-overflow)\s*:\s*(.*?)\s*-->",
+    r"<!--\s*(layout|class|style|notes|title|align|valign|columns|rows|padding|size|cite|cite-left|cite-right|footnote|footnote-right|footnotes|img-align|img-valign|img-fill|img-overflow|animate)\s*:\s*(.*?)\s*-->",
     re.DOTALL,
 )
 
@@ -107,6 +107,8 @@ def parse_slide(text: str) -> Slide:
         elif key == "footnotes":
             if value in {"left", "right"}:
                 metadata["footnotes_position"] = value
+        elif key == "animate":
+            metadata["animate"] = value
         elif key == "columns":
             spec = _normalize_grid_spec(value)
             if spec:

--- a/colloquium/themes/default/presentation.js
+++ b/colloquium/themes/default/presentation.js
@@ -10,6 +10,12 @@ class ColloquiumPresentation {
         this.currentIndex = 0;
         this.totalSlides = this.slides.length;
 
+        // Fragment state: current revealed fragment index per slide (0 = none)
+        this.fragmentStates = this.slides.map(() => 0);
+        this.fragmentCounts = this.slides.map(
+            s => parseInt(s.getAttribute('data-fragment-count') || '0', 10)
+        );
+
         // Reference dimensions (16:9)
         this.width = 1280;
         this.height = 720;
@@ -92,12 +98,20 @@ class ColloquiumPresentation {
         }
     }
 
-    goTo(index) {
+    goTo(index, showAllFragments = false) {
         if (index < 0 || index >= this.totalSlides) return;
 
         this.slides[this.currentIndex].classList.remove('active');
         this.currentIndex = index;
         this.slides[this.currentIndex].classList.add('active');
+
+        // Set fragment state
+        if (showAllFragments) {
+            this.fragmentStates[index] = this.fragmentCounts[index];
+        } else {
+            this.fragmentStates[index] = 0;
+        }
+        this._updateFragments(index);
 
         if (window.colloquiumFitDisplayMathIn) {
             requestAnimationFrame(() => {
@@ -125,11 +139,24 @@ class ColloquiumPresentation {
     }
 
     next() {
-        this.goTo(this.currentIndex + 1);
+        const fc = this.fragmentCounts[this.currentIndex];
+        const fs = this.fragmentStates[this.currentIndex];
+        if (fc > 0 && fs < fc) {
+            this.fragmentStates[this.currentIndex] = fs + 1;
+            this._updateFragments(this.currentIndex);
+        } else {
+            this.goTo(this.currentIndex + 1);
+        }
     }
 
     prev() {
-        this.goTo(this.currentIndex - 1);
+        const fs = this.fragmentStates[this.currentIndex];
+        if (fs > 0) {
+            this.fragmentStates[this.currentIndex] = fs - 1;
+            this._updateFragments(this.currentIndex);
+        } else {
+            this.goTo(this.currentIndex - 1, true);
+        }
     }
 
     first() {
@@ -137,7 +164,19 @@ class ColloquiumPresentation {
     }
 
     last() {
-        this.goTo(this.totalSlides - 1);
+        this.goTo(this.totalSlides - 1, true);
+    }
+
+    // --- Fragment Management ---
+
+    _updateFragments(slideIndex) {
+        const slide = this.slides[slideIndex];
+        const currentStep = this.fragmentStates[slideIndex];
+        const fragments = slide.querySelectorAll('[data-fragment-index]');
+        fragments.forEach(el => {
+            const idx = parseInt(el.getAttribute('data-fragment-index'), 10);
+            el.classList.toggle('visible', idx <= currentStep);
+        });
     }
 
     // --- Slide Picker ---

--- a/colloquium/themes/default/presentation.js
+++ b/colloquium/themes/default/presentation.js
@@ -11,6 +11,12 @@ class ColloquiumPresentation {
         this.totalSlides = this.slides.length;
         this._iframeKeyboardRelayDocuments = new WeakSet();
 
+        // Fragment state: current revealed fragment index per slide (0 = none)
+        this.fragmentStates = this.slides.map(() => 0);
+        this.fragmentCounts = this.slides.map(
+            s => parseInt(s.getAttribute('data-fragment-count') || '0', 10)
+        );
+
         // Reference dimensions (16:9)
         this.width = 1280;
         this.height = 720;
@@ -95,12 +101,20 @@ class ColloquiumPresentation {
         }
     }
 
-    goTo(index) {
+    goTo(index, showAllFragments = false) {
         if (index < 0 || index >= this.totalSlides) return;
 
         this.slides[this.currentIndex].classList.remove('active');
         this.currentIndex = index;
         this.slides[this.currentIndex].classList.add('active');
+
+        // Set fragment state
+        if (showAllFragments) {
+            this.fragmentStates[index] = this.fragmentCounts[index];
+        } else {
+            this.fragmentStates[index] = 0;
+        }
+        this._updateFragments(index);
 
         if (window.colloquiumFitDisplayMathIn) {
             requestAnimationFrame(() => {
@@ -128,11 +142,24 @@ class ColloquiumPresentation {
     }
 
     next() {
-        this.goTo(this.currentIndex + 1);
+        const fc = this.fragmentCounts[this.currentIndex];
+        const fs = this.fragmentStates[this.currentIndex];
+        if (fc > 0 && fs < fc) {
+            this.fragmentStates[this.currentIndex] = fs + 1;
+            this._updateFragments(this.currentIndex);
+        } else {
+            this.goTo(this.currentIndex + 1);
+        }
     }
 
     prev() {
-        this.goTo(this.currentIndex - 1);
+        const fs = this.fragmentStates[this.currentIndex];
+        if (fs > 0) {
+            this.fragmentStates[this.currentIndex] = fs - 1;
+            this._updateFragments(this.currentIndex);
+        } else {
+            this.goTo(this.currentIndex - 1, true);
+        }
     }
 
     first() {
@@ -140,7 +167,19 @@ class ColloquiumPresentation {
     }
 
     last() {
-        this.goTo(this.totalSlides - 1);
+        this.goTo(this.totalSlides - 1, true);
+    }
+
+    // --- Fragment Management ---
+
+    _updateFragments(slideIndex) {
+        const slide = this.slides[slideIndex];
+        const currentStep = this.fragmentStates[slideIndex];
+        const fragments = slide.querySelectorAll('[data-fragment-index]');
+        fragments.forEach(el => {
+            const idx = parseInt(el.getAttribute('data-fragment-index'), 10);
+            el.classList.toggle('visible', idx <= currentStep);
+        });
     }
 
     // --- Slide Picker ---

--- a/colloquium/themes/default/theme.css
+++ b/colloquium/themes/default/theme.css
@@ -946,12 +946,14 @@ html, body {
 }
 
 /* ===== Fragments (incremental reveal) ===== */
-.fragment {
+.fragment[data-fragment-index] {
     opacity: 0;
+    pointer-events: none;
     transition: opacity 0.35s ease;
 }
-.fragment.visible {
+.fragment[data-fragment-index].visible {
     opacity: 1;
+    pointer-events: auto;
 }
 
 /* ===== Footer (inside each slide) ===== */
@@ -1666,8 +1668,9 @@ body:hover .colloquium-present {
     }
 
     /* Show all fragments in print */
-    .fragment {
+    .fragment[data-fragment-index] {
         opacity: 1 !important;
+        pointer-events: auto !important;
         transition: none !important;
     }
 }
@@ -1681,7 +1684,8 @@ body:hover .colloquium-present {
 }
 
 /* Show all fragments in capture mode */
-.colloquium-capture .fragment {
+.colloquium-capture .fragment[data-fragment-index] {
     opacity: 1 !important;
+    pointer-events: auto !important;
     transition: none !important;
 }

--- a/colloquium/themes/default/theme.css
+++ b/colloquium/themes/default/theme.css
@@ -944,6 +944,15 @@ html, body {
     margin-top: 0;
 }
 
+/* ===== Fragments (incremental reveal) ===== */
+.fragment {
+    opacity: 0;
+    transition: opacity 0.35s ease;
+}
+.fragment.visible {
+    opacity: 1;
+}
+
 /* ===== Footer (inside each slide) ===== */
 .colloquium-footer {
     position: absolute;
@@ -1654,6 +1663,12 @@ body:hover .colloquium-present {
     .colloquium-chart-print {
         display: block !important;
     }
+
+    /* Show all fragments in print */
+    .fragment {
+        opacity: 1 !important;
+        transition: none !important;
+    }
 }
 
 /* ===== Capture mode — hide UI chrome for headless screenshots ===== */
@@ -1662,4 +1677,10 @@ body:hover .colloquium-present {
 .colloquium-capture .colloquium-overflow-warn,
 .colloquium-capture .colloquium-picker-overlay {
     display: none !important;
+}
+
+/* Show all fragments in capture mode */
+.colloquium-capture .fragment {
+    opacity: 1 !important;
+    transition: none !important;
 }

--- a/colloquium/themes/default/theme.css
+++ b/colloquium/themes/default/theme.css
@@ -968,12 +968,14 @@ html, body {
 }
 
 /* ===== Fragments (incremental reveal) ===== */
-.fragment {
+.fragment[data-fragment-index] {
     opacity: 0;
+    pointer-events: none;
     transition: opacity 0.35s ease;
 }
-.fragment.visible {
+.fragment[data-fragment-index].visible {
     opacity: 1;
+    pointer-events: auto;
 }
 
 /* ===== Footer (inside each slide) ===== */
@@ -1688,8 +1690,9 @@ body:hover .colloquium-present {
     }
 
     /* Show all fragments in print */
-    .fragment {
+    .fragment[data-fragment-index] {
         opacity: 1 !important;
+        pointer-events: auto !important;
         transition: none !important;
     }
 }
@@ -1703,7 +1706,8 @@ body:hover .colloquium-present {
 }
 
 /* Show all fragments in capture mode */
-.colloquium-capture .fragment {
+.colloquium-capture .fragment[data-fragment-index] {
     opacity: 1 !important;
+    pointer-events: auto !important;
     transition: none !important;
 }

--- a/colloquium/themes/default/theme.css
+++ b/colloquium/themes/default/theme.css
@@ -967,6 +967,15 @@ html, body {
     margin-top: 0;
 }
 
+/* ===== Fragments (incremental reveal) ===== */
+.fragment {
+    opacity: 0;
+    transition: opacity 0.35s ease;
+}
+.fragment.visible {
+    opacity: 1;
+}
+
 /* ===== Footer (inside each slide) ===== */
 .colloquium-footer {
     position: absolute;
@@ -1677,6 +1686,12 @@ body:hover .colloquium-present {
     .colloquium-chart-print {
         display: block !important;
     }
+
+    /* Show all fragments in print */
+    .fragment {
+        opacity: 1 !important;
+        transition: none !important;
+    }
 }
 
 /* ===== Capture mode — hide UI chrome for headless screenshots ===== */
@@ -1685,4 +1700,10 @@ body:hover .colloquium-present {
 .colloquium-capture .colloquium-overflow-warn,
 .colloquium-capture .colloquium-picker-overlay {
     display: none !important;
+}
+
+/* Show all fragments in capture mode */
+.colloquium-capture .fragment {
+    opacity: 1 !important;
+    transition: none !important;
 }

--- a/examples/animations/README.md
+++ b/examples/animations/README.md
@@ -1,0 +1,52 @@
+# Animations
+
+Incrementally reveal bullets, paragraphs, or arbitrary content groups without duplicating slides.
+
+Two composable primitives:
+
+- `<!-- animate: bullets -->` reveals each list item one click at a time
+- `<!-- animate: blocks -->` reveals each top-level block element (paragraph, list, code block) sequentially
+- `<!-- step -->` markers split arbitrary content into reveal groups
+
+Patterns in [`animations.md`](./animations.md):
+
+- bullet-by-bullet reveal
+- block-by-block reveal (paragraphs, lists, code)
+- step markers for arbitrary content grouping
+- composing `animate` + `step` on the same slide
+- animations inside column layouts
+- a plain slide showing backward compatibility
+
+Basic usage:
+
+```md
+## My Slide
+<!-- animate: bullets -->
+
+- First point
+- Second point
+- Third point
+```
+
+Step markers for custom grouping:
+
+```md
+## My Slide
+
+This text appears immediately.
+
+<!-- step -->
+
+This appears on the first click.
+
+<!-- step -->
+
+This appears on the second click.
+```
+
+Notes:
+
+- Navigation steps through fragments before advancing to the next slide.
+- Going backward hides fragments in reverse, then shows the previous slide fully built.
+- Print and PDF export show all content (fragments forced visible).
+- `items` is an alias for `bullets`.

--- a/examples/animations/animations.md
+++ b/examples/animations/animations.md
@@ -1,0 +1,117 @@
+---
+title: Animation Examples
+author: Colloquium
+---
+
+# Animations in Colloquium
+
+Incremental reveal for slides
+
+---
+
+## Bullet-by-Bullet Reveal
+<!-- animate: bullets -->
+
+- First, we define the problem
+- Then, we propose a solution
+- Next, we evaluate the results
+- Finally, we draw conclusions
+
+---
+
+## Block-by-Block Reveal
+<!-- animate: blocks -->
+
+This paragraph appears first.
+
+This paragraph appears second.
+
+This paragraph appears third.
+
+---
+
+## Step Markers
+<!-- size: large -->
+
+This content is visible immediately.
+
+<!-- step -->
+
+This paragraph appears on the first click.
+
+<!-- step -->
+
+And this appears on the second click.
+
+---
+
+## Composing Animate + Steps
+<!-- animate: bullets -->
+
+- Point A
+- Point B
+- Point C
+
+<!-- step -->
+
+After revealing all bullets, this conclusion appears.
+
+---
+
+## Ordered Lists Too
+<!-- animate: items -->
+
+1. Gather requirements
+2. Design the system
+3. Implement the solution
+4. Write tests
+5. Ship it
+
+---
+
+## Blocks with Mixed Content
+<!-- animate: blocks -->
+
+Here is an introductory paragraph.
+
+- A list of items
+- That appears as one block
+
+```python
+# Code appears as another block
+def hello():
+    print("world")
+```
+
+A final paragraph to wrap up.
+
+---
+
+## Steps in Columns
+<!-- columns: 2 -->
+
+### Left Column
+
+Content always visible on the left.
+
+|||
+
+### Right Column
+
+Right column content.
+
+<!-- step -->
+
+More right column content revealed on click.
+
+---
+
+## No Animation
+
+This slide has no animation directives.
+
+All content appears at once, just like before.
+
+- Bullet one
+- Bullet two
+- Bullet three

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1555,3 +1555,41 @@ class TestFragments:
         html = build_deck(deck)
         assert "fragmentStates" in html
         assert "_updateFragments" in html
+
+    def test_li_with_existing_class_gets_fragment_index(self):
+        """Bullets with extra classes must still get data-fragment-index."""
+        from colloquium.build import _apply_auto_animate, _number_fragments
+        html = '<ul>\n<li class="highlight">A</li>\n<li>B</li>\n</ul>'
+        html = _apply_auto_animate(html, "bullets")
+        html, count = _number_fragments(html)
+        assert count == 2
+        assert 'class="fragment highlight" data-fragment-index="1"' in html
+        assert 'class="fragment" data-fragment-index="2"' in html
+
+    def test_step_mixed_content_wraps_non_fragment_blocks(self):
+        """Step groups with bullets + paragraphs must hide paragraphs too."""
+        deck = Deck(title="Test")
+        slide = Slide(
+            title="Mixed",
+            content="- A\n- B\n\n<!-- step -->\n\n- C\n\nConclusion.",
+            metadata={"animate": "bullets"},
+        )
+        deck.slides.append(slide)
+        html = build_deck(deck)
+        # The conclusion paragraph should be in a fragment div
+        assert '<div class="fragment" data-fragment-index=' in html
+        # 2 bullets before step + 1 bullet after + 1 paragraph = 4
+        assert 'data-fragment-count="4"' in html
+
+    def test_step_only_bullets_no_extra_wrapper(self):
+        """Step group with only bullets should not add redundant wrappers."""
+        deck = Deck(title="Test")
+        slide = Slide(
+            title="Pure",
+            content="Intro.\n\n<!-- step -->\n\n- A\n- B",
+            metadata={"animate": "bullets"},
+        )
+        deck.slides.append(slide)
+        html = build_deck(deck)
+        # 2 bullets in the step group, no extra paragraph to wrap
+        assert 'data-fragment-count="2"' in html

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1402,3 +1402,156 @@ class TestCitationRendering:
         assert "\\left[" in html
         assert "\\right]" in html
         assert "colloquium-slide-footnote-text" in html
+
+
+class TestFragments:
+    """Tests for the fragment / incremental reveal system."""
+
+    def test_animate_bullets_adds_fragment_class(self):
+        deck = Deck(title="Test")
+        slide = Slide(
+            title="Bullets",
+            content="- A\n- B\n- C",
+            metadata={"animate": "bullets"},
+        )
+        deck.slides.append(slide)
+        html = build_deck(deck)
+        assert 'class="fragment" data-fragment-index="1"' in html
+        assert 'class="fragment" data-fragment-index="2"' in html
+        assert 'class="fragment" data-fragment-index="3"' in html
+
+    def test_animate_bullets_sets_fragment_count(self):
+        deck = Deck(title="Test")
+        slide = Slide(
+            title="Bullets",
+            content="- A\n- B\n- C",
+            metadata={"animate": "bullets"},
+        )
+        deck.slides.append(slide)
+        html = build_deck(deck)
+        assert 'data-fragment-count="3"' in html
+
+    def test_animate_items_alias(self):
+        deck = Deck(title="Test")
+        slide = Slide(
+            title="Items",
+            content="- X\n- Y",
+            metadata={"animate": "items"},
+        )
+        deck.slides.append(slide)
+        html = build_deck(deck)
+        assert 'data-fragment-count="2"' in html
+
+    def test_animate_blocks_wraps_elements(self):
+        deck = Deck(title="Test")
+        slide = Slide(
+            title="Blocks",
+            content="Para one.\n\nPara two.\n\nPara three.",
+            metadata={"animate": "blocks"},
+        )
+        deck.slides.append(slide)
+        html = build_deck(deck)
+        assert 'data-fragment-count="3"' in html
+        assert '<div class="fragment" data-fragment-index="1"><p>' in html
+
+    def test_step_markers_create_fragments(self):
+        deck = Deck(title="Test")
+        slide = Slide(
+            title="Steps",
+            content="Visible.\n\n<!-- step -->\n\nRevealed.",
+        )
+        deck.slides.append(slide)
+        html = build_deck(deck)
+        assert 'data-fragment-count="1"' in html
+        assert '<div class="fragment" data-fragment-index="1">' in html
+        # Initial content should NOT be in a fragment div
+        assert '<p>Visible.</p>' in html
+
+    def test_step_initial_content_not_wrapped(self):
+        deck = Deck(title="Test")
+        slide = Slide(
+            title="Steps",
+            content="Initial.\n\n<!-- step -->\n\nLater.",
+        )
+        deck.slides.append(slide)
+        html = build_deck(deck)
+        # The initial paragraph should not be wrapped in a fragment div
+        section_start = html.index('class="slide-content"')
+        fragment_start = html.index('class="fragment"', section_start)
+        initial_p = html.index("<p>Initial.</p>", section_start)
+        assert initial_p < fragment_start
+
+    def test_multiple_step_markers(self):
+        deck = Deck(title="Test")
+        slide = Slide(
+            title="Steps",
+            content="A.\n\n<!-- step -->\n\nB.\n\n<!-- step -->\n\nC.",
+        )
+        deck.slides.append(slide)
+        html = build_deck(deck)
+        assert 'data-fragment-count="2"' in html
+        assert 'data-fragment-index="1"' in html
+        assert 'data-fragment-index="2"' in html
+
+    def test_step_and_animate_compose(self):
+        deck = Deck(title="Test")
+        slide = Slide(
+            title="Composed",
+            content="- A\n- B\n\n<!-- step -->\n\nConclusion.",
+            metadata={"animate": "bullets"},
+        )
+        deck.slides.append(slide)
+        html = build_deck(deck)
+        # 2 bullets + 1 step group = 3 fragments
+        assert 'data-fragment-count="3"' in html
+        assert 'data-fragment-index="1"' in html
+        assert 'data-fragment-index="2"' in html
+        assert 'data-fragment-index="3"' in html
+
+    def test_no_animate_no_step_no_fragments(self):
+        deck = Deck(title="Test")
+        slide = Slide(title="Plain", content="Just text.")
+        deck.slides.append(slide)
+        html = build_deck(deck)
+        # The section tag should not have data-fragment-count
+        import re
+        section = re.search(r'<section[^>]*data-index="0"[^>]*>', html).group()
+        assert "data-fragment-count" not in section
+        assert 'data-fragment-index' not in html.split("<script>")[0]
+        assert 'class="fragment"' not in html.split("<script>")[0]
+
+    def test_fragment_css_present(self):
+        deck = Deck(title="Test")
+        slide = Slide(
+            title="Bullets",
+            content="- A",
+            metadata={"animate": "bullets"},
+        )
+        deck.slides.append(slide)
+        html = build_deck(deck)
+        assert ".fragment {" in html
+        assert ".fragment.visible {" in html
+
+    def test_print_css_shows_fragments(self):
+        deck = Deck(title="Test")
+        deck.add_slide(title="S", content="text")
+        html = build_deck(deck)
+        assert "@media print" in html
+        # Print block should force fragments visible
+        print_idx = html.index("@media print")
+        closing_brace = html.index("}", html.index(".fragment", print_idx))
+        print_fragment_section = html[print_idx:closing_brace]
+        assert "opacity: 1" in print_fragment_section
+
+    def test_capture_mode_shows_fragments(self):
+        deck = Deck(title="Test")
+        deck.add_slide(title="S", content="text")
+        html = build_deck(deck)
+        assert ".colloquium-capture .fragment" in html
+
+    def test_fragment_js_present(self):
+        deck = Deck(title="Test")
+        deck.add_slide(title="S", content="text")
+        html = build_deck(deck)
+        assert "fragmentStates" in html
+        assert "_updateFragments" in html

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1516,9 +1516,11 @@ class TestFragments:
         # The section tag should not have data-fragment-count
         import re
         section = re.search(r'<section[^>]*data-index="0"[^>]*>', html).group()
+        section_start = html.index(section)
+        section_html = html[section_start:html.index("</section>", section_start)]
         assert "data-fragment-count" not in section
-        assert 'data-fragment-index' not in html.split("<script>")[0]
-        assert 'class="fragment"' not in html.split("<script>")[0]
+        assert 'data-fragment-index' not in section_html
+        assert 'class="fragment"' not in section_html
 
     def test_fragment_css_present(self):
         deck = Deck(title="Test")
@@ -1529,8 +1531,10 @@ class TestFragments:
         )
         deck.slides.append(slide)
         html = build_deck(deck)
-        assert ".fragment {" in html
-        assert ".fragment.visible {" in html
+        assert ".fragment[data-fragment-index] {" in html
+        assert ".fragment[data-fragment-index].visible {" in html
+        assert "pointer-events: none" in html
+        assert "pointer-events: auto" in html
 
     def test_print_css_shows_fragments(self):
         deck = Deck(title="Test")
@@ -1539,7 +1543,7 @@ class TestFragments:
         assert "@media print" in html
         # Print block should force fragments visible
         print_idx = html.index("@media print")
-        closing_brace = html.index("}", html.index(".fragment", print_idx))
+        closing_brace = html.index("}", html.index(".fragment[data-fragment-index]", print_idx))
         print_fragment_section = html[print_idx:closing_brace]
         assert "opacity: 1" in print_fragment_section
 
@@ -1547,7 +1551,7 @@ class TestFragments:
         deck = Deck(title="Test")
         deck.add_slide(title="S", content="text")
         html = build_deck(deck)
-        assert ".colloquium-capture .fragment" in html
+        assert ".colloquium-capture .fragment[data-fragment-index]" in html
 
     def test_fragment_js_present(self):
         deck = Deck(title="Test")
@@ -1556,15 +1560,36 @@ class TestFragments:
         assert "fragmentStates" in html
         assert "_updateFragments" in html
 
-    def test_li_with_existing_class_gets_fragment_index(self):
-        """Bullets with extra classes must still get data-fragment-index."""
+    def test_li_with_arbitrary_attributes_gets_fragment_index(self):
+        """Bullets with any attribute order must still get data-fragment-index."""
         from colloquium.build import _apply_auto_animate, _number_fragments
-        html = '<ul>\n<li class="highlight">A</li>\n<li>B</li>\n</ul>'
+        html = (
+            '<ul>\n'
+            '<li id="first" class="highlight">A</li>\n'
+            '<li data-id="2">B</li>\n'
+            '</ul>'
+        )
         html = _apply_auto_animate(html, "bullets")
         html, count = _number_fragments(html)
         assert count == 2
-        assert 'class="fragment highlight" data-fragment-index="1"' in html
-        assert 'class="fragment" data-fragment-index="2"' in html
+        assert '<li id="first" class="fragment highlight" data-fragment-index="1">' in html
+        assert '<li data-id="2" class="fragment" data-fragment-index="2">' in html
+
+    def test_custom_fragment_class_without_animation_is_untouched(self):
+        deck = Deck(title="Test")
+        slide = Slide(
+            title="Plain",
+            content='<div class="fragment">Visible custom fragment</div>',
+        )
+        deck.slides.append(slide)
+        html = build_deck(deck)
+        import re
+        section = re.search(r'<section[^>]*data-index="0"[^>]*>', html).group()
+        section_start = html.index(section)
+        section_html = html[section_start:html.index("</section>", section_start)]
+        assert "data-fragment-count" not in section
+        assert 'data-fragment-index' not in section_html
+        assert 'class="fragment">Visible custom fragment</div>' in section_html
 
     def test_step_mixed_content_wraps_non_fragment_blocks(self):
         """Step groups with bullets + paragraphs must hide paragraphs too."""

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1593,3 +1593,46 @@ class TestFragments:
         html = build_deck(deck)
         # 2 bullets in the step group, no extra paragraph to wrap
         assert 'data-fragment-count="2"' in html
+
+    def test_blocks_with_columns(self):
+        """Blocks mode must wrap paragraphs inside each column, not across."""
+        deck = Deck(title="Test")
+        slide = Slide(
+            title="Cols",
+            content="P1\n\nP2\n\n|||\n\nP3\n\nP4",
+            classes=["cols-2"],
+            metadata={"animate": "blocks"},
+        )
+        deck.slides.append(slide)
+        html = build_deck(deck)
+        assert 'data-fragment-count="4"' in html
+        # Each paragraph wrapped individually inside its column div
+        assert '<div class="col"><div class="fragment"' in html
+
+    def test_blocks_with_rows(self):
+        """Blocks mode must wrap paragraphs inside each row, not across."""
+        deck = Deck(title="Test")
+        slide = Slide(
+            title="Rows",
+            content="P1\n\nP2\n\n===\n\nP3\n\nP4",
+            classes=["rows-2"],
+            metadata={"animate": "blocks"},
+        )
+        deck.slides.append(slide)
+        html = build_deck(deck)
+        assert 'data-fragment-count="4"' in html
+        assert '<div class="colloquium-row"><div class="fragment"' in html
+
+    def test_step_blockquote_with_nested_bullets(self):
+        """Step group with a blockquote containing fragments must wrap the blockquote."""
+        deck = Deck(title="Test")
+        slide = Slide(
+            title="BQ",
+            content="Intro.\n\n<!-- step -->\n\n> Note\n>\n> - A\n> - B",
+            metadata={"animate": "bullets"},
+        )
+        deck.slides.append(slide)
+        html = build_deck(deck)
+        # blockquote (frag 1) wraps the <p> and bullets (frags 2, 3)
+        assert 'data-fragment-count="3"' in html
+        assert '<div class="fragment" data-fragment-index="1"><blockquote>' in html

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1648,6 +1648,26 @@ class TestFragments:
         assert 'data-fragment-count="4"' in html
         assert '<div class="colloquium-row"><div class="fragment"' in html
 
+    def test_blocks_wraps_markdown_headings(self):
+        """Blocks mode must treat markdown headings as top-level fragments."""
+        deck = Deck(title="Test")
+        slide = Slide(
+            title="Headings",
+            content="### Section\n\nDetails.",
+            metadata={"animate": "blocks"},
+        )
+        deck.slides.append(slide)
+        html = build_deck(deck)
+        assert 'data-fragment-count="2"' in html
+        assert (
+            '<div class="fragment" data-fragment-index="1">'
+            '<h3>Section</h3></div>'
+        ) in html
+        assert (
+            '<div class="fragment" data-fragment-index="2">'
+            '<p>Details.</p></div>'
+        ) in html
+
     def test_step_with_columns_preserves_column_boundaries(self):
         """Step fragments in a column must not wrap sibling column divs."""
         deck = Deck(title="Test")

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1648,6 +1648,40 @@ class TestFragments:
         assert 'data-fragment-count="4"' in html
         assert '<div class="colloquium-row"><div class="fragment"' in html
 
+    def test_step_with_columns_preserves_column_boundaries(self):
+        """Step fragments in a column must not wrap sibling column divs."""
+        deck = Deck(title="Test")
+        slide = Slide(
+            title="Cols",
+            content="Left\n\n<!-- step -->\n\nLeft step\n\n|||\n\nRight",
+            classes=["cols-2"],
+        )
+        deck.slides.append(slide)
+        html = build_deck(deck)
+        assert 'data-fragment-count="1"' in html
+        assert (
+            '<div class="col"><p>Left</p>\n'
+            '<div class="fragment" data-fragment-index="1"><p>Left step</p></div>'
+            '</div><div class="col"><p>Right</p></div>'
+        ) in html
+
+    def test_step_with_rows_preserves_row_boundaries(self):
+        """Step fragments in a row must not wrap sibling row divs."""
+        deck = Deck(title="Test")
+        slide = Slide(
+            title="Rows",
+            content="Top\n\n<!-- step -->\n\nTop step\n\n===\n\nBottom",
+            classes=["rows-2"],
+        )
+        deck.slides.append(slide)
+        html = build_deck(deck)
+        assert 'data-fragment-count="1"' in html
+        assert (
+            '<div class="colloquium-row"><p>Top</p>\n'
+            '<div class="fragment" data-fragment-index="1"><p>Top step</p></div>'
+            '</div><div class="colloquium-row"><p>Bottom</p>\n</div>'
+        ) in html
+
     def test_step_blockquote_with_nested_bullets(self):
         """Step group with a blockquote containing fragments must wrap the blockquote."""
         deck = Deck(title="Test")

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -287,3 +287,30 @@ Some math: $E = mc^2$
         text = "---\ntitle: Talk\nfigure_captions: true\n---\n\n## S1\n\n![Caption](image.png)"
         deck = parse_markdown(text)
         assert deck.figure_captions is True
+
+
+class TestAnimateDirective:
+    def test_animate_stored_in_metadata(self):
+        slide = parse_slide("## Title\n<!-- animate: bullets -->\n\n- A\n- B")
+        assert slide.metadata["animate"] == "bullets"
+
+    def test_animate_removed_from_content(self):
+        slide = parse_slide("## Title\n<!-- animate: bullets -->\n\n- A\n- B")
+        assert "animate" not in slide.content
+        assert "<!--" not in slide.content
+
+    def test_animate_blocks_stored(self):
+        slide = parse_slide("## Title\n<!-- animate: blocks -->\n\nParagraph")
+        assert slide.metadata["animate"] == "blocks"
+
+    def test_step_marker_not_consumed(self):
+        """Step markers have no colon so should NOT match the directive regex."""
+        slide = parse_slide("## Title\n\nBefore\n\n<!-- step -->\n\nAfter")
+        assert "<!-- step -->" in slide.content
+
+    def test_animate_and_step_coexist(self):
+        slide = parse_slide(
+            "## Title\n<!-- animate: bullets -->\n\n- A\n\n<!-- step -->\n\nText"
+        )
+        assert slide.metadata["animate"] == "bullets"
+        assert "<!-- step -->" in slide.content


### PR DESCRIPTION
## Summary

- Adds `<!-- animate: bullets|items|blocks -->` directive to auto-fragment list items or block elements for one-click-at-a-time reveal
- Adds `<!-- step -->` content markers to split arbitrary content into reveal groups
- Both primitives compose naturally — bullets animate within step groups, fragments numbered sequentially
- Navigation steps through fragments before advancing slides; backward shows previous slide fully built
- Print and capture modes force all fragments visible (no content lost in PDFs)
- Fully backward compatible — slides without animation directives work exactly as before

## Changed files

| File | What |
|------|------|
| `colloquium/parse.py` | `animate` added to directive regex |
| `colloquium/build.py` | 5 new functions for fragment HTML processing |
| `themes/default/presentation.js` | Fragment state tracking, modified next/prev/goTo |
| `themes/default/theme.css` | `.fragment` / `.fragment.visible` + print/capture overrides |
| `tests/test_parse.py` | 5 new tests |
| `tests/test_build.py` | 13 new tests |
| `examples/animations/` | New showcase deck |

## Test plan

- [x] `uv run pytest` — 205 passed, 1 skipped
- [x] `uv run colloquium build examples/hello/hello.md` — existing example unchanged
- [x] `uv run colloquium build examples/animations/animations.md` — new example builds correctly
- [ ] Open animations.html in browser — click through fragments, verify reveal behavior
- [ ] Test backward navigation (fragments hide in reverse, previous slide shows fully built)
- [ ] Test Cmd+P print preview — all content visible
- [ ] Test Home/End keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)