### PR TITLE
fix: errors out on port reuse, but still enables quick restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ One line per PR for easy copy into GitHub releases.
 
 ## [Unreleased]
 
+- Bind dev server to loopback, change default port to 8090, and error on port conflicts ([#28](https://github.com/natolambert/colloquium/pull/28))
+
 ## [0.2.1] - 2026-03-25
 
 - Fix chart rendering breaking slide navigation when data contains single quotes ([#20](https://github.com/natolambert/colloquium/pull/20))

--- a/colloquium/cli.py
+++ b/colloquium/cli.py
@@ -29,14 +29,18 @@ def _build(args):
 
 def _serve(args):
     """Serve a presentation with live reload."""
-    from colloquium.serve import serve
+    from colloquium.serve import PortUnavailableError, serve
 
     input_path = args.file
     if not Path(input_path).exists():
         print(f"Error: {input_path} not found", file=sys.stderr)
         sys.exit(1)
 
-    serve(input_path, port=args.port)
+    try:
+        serve(input_path, port=args.port)
+    except PortUnavailableError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
 
 
 def _export(args):
@@ -119,7 +123,7 @@ def main():
     # serve
     serve_parser = subparsers.add_parser("serve", help="Dev server with live reload")
     serve_parser.add_argument("file", help="Input markdown file")
-    serve_parser.add_argument("-p", "--port", type=int, default=8080, help="Port (default: 8080)")
+    serve_parser.add_argument("-p", "--port", type=int, default=8090, help="Port (default: 8090)")
     serve_parser.set_defaults(func=_serve)
 
     # export

--- a/colloquium/serve.py
+++ b/colloquium/serve.py
@@ -116,6 +116,15 @@ def _build_snapshot_html(input_path: str, text: str) -> str:
 # After this many seconds of "unstable", build anyway to avoid getting
 # permanently stuck.
 _MAX_STABLE_WAIT = 3.0
+_DEFAULT_HOST = "127.0.0.1"
+
+
+class PortUnavailableError(RuntimeError):
+    """Raised when the dev server cannot bind to the requested port."""
+
+    def __init__(self, port: int, cause: OSError):
+        detail = cause.strerror or str(cause)
+        super().__init__(f"Port {port} is unavailable: {detail}")
 
 
 def _watch_and_rebuild(input_path: str, output_path: str, stop_event: threading.Event):
@@ -180,7 +189,23 @@ def _watch_and_rebuild(input_path: str, output_path: str, stop_event: threading.
         stop_event.wait(timeout=0.15)
 
 
-def serve(input_path: str, port: int = 8080, output_dir: str | None = None):
+def _create_http_server(port: int, handler):
+    """Create the HTTP server bound to loopback with address reuse enabled.
+
+    This preserves immediate restarts after ``TIME_WAIT`` while still
+    rejecting the macOS overlap case caused by wildcard binds.
+    """
+
+    class PresentationTCPServer(socketserver.TCPServer):
+        allow_reuse_address = True
+
+    try:
+        return PresentationTCPServer((_DEFAULT_HOST, port), handler)
+    except OSError as exc:
+        raise PortUnavailableError(port, exc) from exc
+
+
+def serve(input_path: str, port: int = 8090, output_dir: str | None = None):
     """Serve a presentation with live rebuilding on file changes."""
     from colloquium.build import build_file
 
@@ -211,19 +236,14 @@ def serve(input_path: str, port: int = 8080, output_dir: str | None = None):
     # Serve from the output directory
     os.chdir(serve_dir)
 
-    handler = http.server.SimpleHTTPRequestHandler
-
     # Suppress request logging
-    class QuietHandler(handler):
+    class QuietHandler(http.server.SimpleHTTPRequestHandler):
         def log_message(self, format, *args):
             pass
 
-    class ReusableTCPServer(socketserver.TCPServer):
-        allow_reuse_address = True
-
     try:
-        with ReusableTCPServer(("", port), QuietHandler) as httpd:
-            url = f"http://localhost:{port}/{stem}.html"
+        with _create_http_server(port, QuietHandler) as httpd:
+            url = f"http://{_DEFAULT_HOST}:{port}/{stem}.html"
             print(f"  Serving at {url}")
             print(f"  Watching for changes... (Ctrl+C to stop)")
             httpd.serve_forever()

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -1,13 +1,21 @@
 """Tests for live-reload stability checks."""
 
+import http.server
+import socket
+import socketserver
+
+import pytest
+
 from colloquium.serve import (
     _build_snapshot_html,
+    _create_http_server,
     _has_unclosed_fenced_code_block,
     _has_unclosed_html_comment,
     _read_quiescent_source,
     _read_stable_source_snapshot,
     _render_matches_deck_structure,
     _source_text_is_stable_for_rebuild,
+    PortUnavailableError,
 )
 from colloquium.parse import parse_markdown
 
@@ -113,3 +121,29 @@ class TestServeStabilityChecks:
     def test_unclosed_tilde_fences(self):
         text = "~~~python\nprint('hi')\n\n## Slide"
         assert _has_unclosed_fenced_code_block(text)
+
+
+class TestServePortBinding:
+    def test_create_http_server_binds_loopback_with_so_reuseaddr_enabled(self):
+        httpd = _create_http_server(0, http.server.SimpleHTTPRequestHandler)
+
+        try:
+            assert httpd.allow_reuse_address is True
+            assert httpd.server_address[0] == "127.0.0.1"
+            assert httpd.socket.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR) != 0
+        finally:
+            httpd.server_close()
+
+    def test_create_http_server_rejects_port_already_in_use(self):
+        class NoopHandler(socketserver.BaseRequestHandler):
+            def handle(self):
+                pass
+
+        with socketserver.TCPServer(("127.0.0.1", 0), NoopHandler) as existing:
+            port = existing.server_address[1]
+
+            with pytest.raises(
+                PortUnavailableError,
+                match=rf"Port {port} is unavailable",
+            ):
+                _create_http_server(port, http.server.SimpleHTTPRequestHandler)


### PR DESCRIPTION
# Overview
This fixes the macOS port-overlap case reported in #26 (by myself) while preserving the normal stop/restart workflow for `colloquium serve`.

  Changes in this PR:
  - change the default serve port from `8080` to `8090`
  - raise a clear CLI error when the requested port is unavailable
  - bind the dev server to `127.0.0.1` instead of a wildcard address
  - keep address reuse enabled so immediate restarts still work after `Ctrl+C`
  - add regression tests for the new port-binding behavior

  The final fix keeps allow_reuse_address = True for fast restarts, but binds Colloquium to 127.0.0.1 instead of a wildcard address. That gives us the behavior we want:

  - immediate restart after Ctrl+C still works
  - Colloquium now fails cleanly if `127.0.0.1:<port>` is already in use
  - the issue repro no longer silently reports a successful startup

  ## How this was tested

  Automated:

  - uv run --locked --extra dev pytest
  - Result: 189 passed, 1 skipped

  Manual repro from #26:

  1. Start a loopback-only HTTP server on `127.0.0.1:39130`
  2. Run `uv run --locked colloquium serve /tmp/colloquium-deck-mre/slides.md -p 39130`
  3. Observe:
  ```bash
     Error: Port 39130 is unavailable: Address already in use
  ```
  5. Confirm only the original loopback server is listening on that port