### PR TITLE
Upgrade pytest to 9.0.3 and Pygments to 2.20.0 (CVE-2025-71176, CVE-2026-4539)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ One line per PR for easy copy into GitHub releases.
 
 - Bind dev server to loopback, change default port to 8090, and error on port conflicts ([#28](https://github.com/natolambert/colloquium/pull/28))
 - Upgrade locked Pillow to 12.2.0 to fix CVE-2026-40192 ([#29](https://github.com/natolambert/colloquium/pull/29))
+- Upgrade locked pytest to 9.0.3 and Pygments to 2.20.0 to fix CVE-2025-71176 and CVE-2026-4539 ([#30](https://github.com/natolambert/colloquium/pull/30))
 
 ## [0.2.1] - 2026-03-25
 

--- a/uv.lock
+++ b/uv.lock
@@ -359,16 +359,16 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -379,9 +379,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Addresses two Dependabot alerts against `uv.lock`:

- **[#3](https://github.com/natolambert/colloquium/security/dependabot/3)** — [CVE-2025-71176](https://nvd.nist.gov/vuln/detail/CVE-2025-71176) / GHSA-6w46-j5rx-g56g (medium): `pytest < 9.0.3` uses predictable `/tmp/pytest-of-{user}` directories, which can allow a local user to cause DoS or gain privileges. Fixed in pytest 9.0.3.
- **[#2](https://github.com/natolambert/colloquium/security/dependabot/2)** — [CVE-2026-4539](https://nvd.nist.gov/vuln/detail/CVE-2026-4539) / GHSA-5239-wwwm-4pmq (low): `Pygments < 2.20.0` has a ReDoS in the archetype `AdlLexer`. Fixed in Pygments 2.20.0.

Both packages are dev-only — pytest is in the `dev` extra, and Pygments is pulled in transitively by pytest. Neither is a runtime dependency of colloquium, so end users installing `colloquium` are not affected.

Changes:
- `uv lock --upgrade-package pytest --upgrade-package pygments` → pytest `9.0.2 → 9.0.3`, Pygments `2.19.2 → 2.20.0`
- Changelog entry under `[Unreleased]`

## Test plan

- [x] `uv run pytest` — 189 passed, 1 skipped on pytest 9.0.3
- [ ] Dependabot alerts #2 and #3 close automatically after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)