### PR TITLE
add built-in iframe element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ One line per PR for easy copy into GitHub releases.
 - Upgrade locked Pillow to 12.2.0 to fix CVE-2026-40192 ([#29](https://github.com/natolambert/colloquium/pull/29))
 - Upgrade locked pytest to 9.0.3 and Pygments to 2.20.0 to fix CVE-2025-71176 and CVE-2026-4539 ([#30](https://github.com/natolambert/colloquium/pull/30))
 - Upgrade locked lxml to 6.1.0 to fix CVE-2026-41066 (XXE in iterparse/ETCompatXMLParser) ([#31](https://github.com/natolambert/colloquium/pull/31))
+- Add a built-in iframe element for embedding external or local HTML content ([#32](https://github.com/natolambert/colloquium/pull/32))
 
 ## [0.2.1] - 2026-03-25
 

--- a/colloquium/elements/__init__.py
+++ b/colloquium/elements/__init__.py
@@ -21,11 +21,18 @@ from colloquium.elements.conversation import (
     reset as reset_conversations,
 )
 
+from colloquium.elements.iframe import (
+    PATTERN as IFRAME_PATTERN,
+    process as process_iframe,
+    reset as reset_iframes,
+)
+
 ELEMENTS = [
     (BUILTWITH_PATTERN, process_builtwith),
     (BOX_PATTERN, process_box),
     (CHART_PATTERN, process_chart),
     (CONV_PATTERN, process_conversation),
+    (IFRAME_PATTERN, process_iframe),
 ]
 
 
@@ -42,3 +49,4 @@ def reset() -> None:
     reset_boxes()
     reset_charts()
     reset_conversations()
+    reset_iframes()

--- a/colloquium/elements/iframe.py
+++ b/colloquium/elements/iframe.py
@@ -1,19 +1,73 @@
 import html as html_module
 import re
+
 import yaml
 
 PATTERN = re.compile(r'<pre><code class="language-iframe">(.*?)</code></pre>', re.DOTALL)
 IFRAME_DEFAULT_HEIGHT = 480
+IFRAME_DEFAULT_LOADING = "lazy"
+IFRAME_DEFAULT_WIDTH = "100%"
+_FALSE_VALUES = {"false", "off", "0", "no"}
+
 
 def reset() -> None:
     return None
 
-def _height(v):
+
+def _height(value) -> int:
     try:
-        n = int(v)
-        return n if n > 0 else IFRAME_DEFAULT_HEIGHT
+        height = int(value)
+        return height if height > 0 else IFRAME_DEFAULT_HEIGHT
     except (TypeError, ValueError):
         return IFRAME_DEFAULT_HEIGHT
+
+
+def _width(value) -> str:
+    if value is None or value == "":
+        return IFRAME_DEFAULT_WIDTH
+    text = str(value).strip()
+    if not text:
+        return IFRAME_DEFAULT_WIDTH
+    if text.endswith("%"):
+        try:
+            return text if float(text[:-1]) > 0 else IFRAME_DEFAULT_WIDTH
+        except ValueError:
+            return IFRAME_DEFAULT_WIDTH
+    try:
+        width = int(text)
+        return str(width) if width > 0 else IFRAME_DEFAULT_WIDTH
+    except ValueError:
+        return IFRAME_DEFAULT_WIDTH
+
+
+def _loading(value) -> str:
+    loading = str(value or IFRAME_DEFAULT_LOADING).strip().lower()
+    return loading if loading in {"lazy", "eager"} else IFRAME_DEFAULT_LOADING
+
+
+def _allowfullscreen(value) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() not in _FALSE_VALUES
+    return bool(value)
+
+
+def _scrolling(value) -> str | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    scrolling = str(value).strip().lower()
+    return scrolling if scrolling in {"auto", "yes", "no"} else None
+
+
+def _frameborder(value) -> str:
+    frameborder = str(value if value is not None else "0").strip()
+    return frameborder if frameborder in {"0", "1"} else "0"
+
+
+def _width_css(width: str) -> str:
+    return f"{width}px" if width.isdigit() else width
+
 
 def process(yaml_str: str) -> str:
     raw = html_module.unescape(yaml_str.strip())
@@ -24,20 +78,41 @@ def process(yaml_str: str) -> str:
     if not isinstance(spec, dict):
         return '<p style="color:red">Iframe spec must be a YAML mapping</p>'
 
-    src = str(spec.get("src", "")).strip()
+    src_value = spec.get("src")
+    src = src_value.strip() if isinstance(src_value, str) else ""
     if not src:
         return '<p style="color:red">Iframe requires src</p>'
 
-    h = _height(spec.get("height", IFRAME_DEFAULT_HEIGHT))
-    title = html_module.escape(str(spec.get("title", "")).strip())
-    loading = html_module.escape(str(spec.get("loading", "lazy")).strip() or "lazy")
-    allow = spec.get("allowfullscreen", True) not in {False, "false", "off", "0"}
+    height = _height(spec.get("height", IFRAME_DEFAULT_HEIGHT))
+    width = _width(spec.get("width", IFRAME_DEFAULT_WIDTH))
+    title = html_module.escape(str(spec.get("title", "") or "").strip(), quote=True)
+    loading = html_module.escape(
+        _loading(spec.get("loading", IFRAME_DEFAULT_LOADING)),
+        quote=True,
+    )
+    allow = _allowfullscreen(spec.get("allowfullscreen", True))
+    scrolling = _scrolling(spec.get("scrolling"))
+    frameborder = html_module.escape(
+        _frameborder(spec.get("frameborder", "0")),
+        quote=True,
+    )
+    style_value = spec.get("style")
+    style = (
+        str(style_value).strip()
+        if style_value is not None and style_value != ""
+        else f"border:none;display:block;width:{_width_css(width)};height:{height}px"
+    )
 
     src_attr = html_module.escape(src, quote=True)
     allow_attr = " allowfullscreen" if allow else ""
+    scrolling_attr = (
+        f' scrolling="{html_module.escape(scrolling, quote=True)}"' if scrolling else ""
+    )
+    container_style = f"width:{_width_css(width)};height:auto;min-height:{height}px;"
     return (
-        f'<div class="colloquium-iframe-container" style="width:100%;height:auto;min-height:{h}px;">'
+        f'<div class="colloquium-iframe-container" style="{container_style}">'
         f'<iframe class="colloquium-iframe" src="{src_attr}" title="{title}" loading="{loading}" '
-        f'width="100%" height="{h}" frameborder="0"{allow_attr} '
-        f'style="border:none;display:block;width:100%;height:{h}px"></iframe></div>'
+        f'width="{html_module.escape(width, quote=True)}" height="{height}" '
+        f'frameborder="{frameborder}"{scrolling_attr}{allow_attr} '
+        f'style="{html_module.escape(style, quote=True)}"></iframe></div>'
     )

--- a/colloquium/elements/iframe.py
+++ b/colloquium/elements/iframe.py
@@ -5,7 +5,7 @@ import yaml
 
 PATTERN = re.compile(r'<pre><code class="language-iframe">(.*?)</code></pre>', re.DOTALL)
 IFRAME_DEFAULT_HEIGHT = 480
-IFRAME_DEFAULT_LOADING = "lazy"
+IFRAME_DEFAULT_LOADING = "eager"
 IFRAME_DEFAULT_WIDTH = "100%"
 _FALSE_VALUES = {"false", "off", "0", "no"}
 
@@ -91,6 +91,7 @@ def process(yaml_str: str) -> str:
         quote=True,
     )
     allow = _allowfullscreen(spec.get("allowfullscreen", True))
+    preserve_keyboard = _allowfullscreen(spec.get("preserve_keyboard", True))
     scrolling = _scrolling(spec.get("scrolling"))
     frameborder = html_module.escape(
         _frameborder(spec.get("frameborder", "0")),
@@ -105,6 +106,7 @@ def process(yaml_str: str) -> str:
 
     src_attr = html_module.escape(src, quote=True)
     allow_attr = " allowfullscreen" if allow else ""
+    keyboard_attr = str(preserve_keyboard).lower()
     scrolling_attr = (
         f' scrolling="{html_module.escape(scrolling, quote=True)}"' if scrolling else ""
     )
@@ -112,6 +114,7 @@ def process(yaml_str: str) -> str:
     return (
         f'<div class="colloquium-iframe-container" style="{container_style}">'
         f'<iframe class="colloquium-iframe" src="{src_attr}" title="{title}" loading="{loading}" '
+        f'data-colloquium-preserve-keyboard="{keyboard_attr}" '
         f'width="{html_module.escape(width, quote=True)}" height="{height}" '
         f'frameborder="{frameborder}"{scrolling_attr}{allow_attr} '
         f'style="{html_module.escape(style, quote=True)}"></iframe></div>'

--- a/colloquium/elements/iframe.py
+++ b/colloquium/elements/iframe.py
@@ -1,0 +1,43 @@
+import html as html_module
+import re
+import yaml
+
+PATTERN = re.compile(r'<pre><code class="language-iframe">(.*?)</code></pre>', re.DOTALL)
+IFRAME_DEFAULT_HEIGHT = 480
+
+def reset() -> None:
+    return None
+
+def _height(v):
+    try:
+        n = int(v)
+        return n if n > 0 else IFRAME_DEFAULT_HEIGHT
+    except (TypeError, ValueError):
+        return IFRAME_DEFAULT_HEIGHT
+
+def process(yaml_str: str) -> str:
+    raw = html_module.unescape(yaml_str.strip())
+    try:
+        spec = yaml.safe_load(raw)
+    except yaml.YAMLError:
+        return '<p style="color:red">Invalid iframe YAML</p>'
+    if not isinstance(spec, dict):
+        return '<p style="color:red">Iframe spec must be a YAML mapping</p>'
+
+    src = str(spec.get("src", "")).strip()
+    if not src:
+        return '<p style="color:red">Iframe requires src</p>'
+
+    h = _height(spec.get("height", IFRAME_DEFAULT_HEIGHT))
+    title = html_module.escape(str(spec.get("title", "")).strip())
+    loading = html_module.escape(str(spec.get("loading", "lazy")).strip() or "lazy")
+    allow = spec.get("allowfullscreen", True) not in {False, "false", "off", "0"}
+
+    src_attr = html_module.escape(src, quote=True)
+    allow_attr = " allowfullscreen" if allow else ""
+    return (
+        f'<div class="colloquium-iframe-container" style="width:100%;height:auto;min-height:{h}px;">'
+        f'<iframe class="colloquium-iframe" src="{src_attr}" title="{title}" loading="{loading}" '
+        f'width="100%" height="{h}" frameborder="0"{allow_attr} '
+        f'style="border:none;display:block;width:100%;height:{h}px"></iframe></div>'
+    )

--- a/colloquium/export.py
+++ b/colloquium/export.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
+import http.server
 import os
 import shutil
+import socketserver
 import subprocess
 import tempfile
+import threading
+from contextlib import contextmanager
+from functools import partial
 from pathlib import Path
+from urllib.parse import quote
 
 
 def _find_browser() -> str | None:
@@ -39,9 +45,39 @@ def _is_chromium_based(browser_path: str) -> bool:
     return any(x in name for x in ["chrome", "chromium", "edge", "brave"])
 
 
+@contextmanager
+def _serve_html_for_export(html_path: str):
+    """Serve an HTML deck over loopback while Chromium prints it.
+
+    Loading decks from ``file://`` can leave cross-origin iframes blank in
+    Chromium's print-to-PDF path even when the same page renders normally.
+    Serving the deck over HTTP preserves relative assets and lets embedded
+    frames load in the same browser mode users preview locally.
+    """
+    html_file = Path(html_path).resolve()
+
+    class QuietHandler(http.server.SimpleHTTPRequestHandler):
+        def log_message(self, format, *args):
+            pass
+
+    class ExportTCPServer(socketserver.TCPServer):
+        allow_reuse_address = True
+
+    handler = partial(QuietHandler, directory=str(html_file.parent))
+
+    with ExportTCPServer(("127.0.0.1", 0), handler) as httpd:
+        thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+        thread.start()
+        try:
+            host, port = httpd.server_address
+            yield f"http://{host}:{port}/{quote(html_file.name)}"
+        finally:
+            httpd.shutdown()
+            thread.join(timeout=2)
+
+
 def _export_pdf_from_html(html_path: str, output_path: str) -> str | None:
     """Export an existing HTML deck to PDF using a system browser."""
-    html_url = f"file://{Path(html_path).resolve()}"
     browser = _find_browser()
     if browser is None:
         return None
@@ -51,24 +87,25 @@ def _export_pdf_from_html(html_path: str, output_path: str) -> str | None:
 
     # Use Chromium's headless print-to-pdf
     # 10in x 5.625in = 16:9 landscape, matching @page size in print CSS
-    cmd = [
-        browser,
-        "--headless",
-        "--disable-gpu",
-        f"--print-to-pdf={output_path}",
-        "--no-pdf-header-footer",
-        "--print-to-pdf-no-header",
-        "--no-margins",
-        f"--paper-width=10",
-        f"--paper-height=5.625",
-        "--virtual-time-budget=5000",
-        html_url,
-    ]
+    with _serve_html_for_export(html_path) as html_url:
+        cmd = [
+            browser,
+            "--headless",
+            "--disable-gpu",
+            f"--print-to-pdf={output_path}",
+            "--no-pdf-header-footer",
+            "--print-to-pdf-no-header",
+            "--no-margins",
+            f"--paper-width=10",
+            f"--paper-height=5.625",
+            "--virtual-time-budget=5000",
+            html_url,
+        ]
 
-    try:
-        subprocess.run(cmd, capture_output=True, timeout=30, check=True)
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
-        return None
+        try:
+            subprocess.run(cmd, capture_output=True, timeout=30, check=True)
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+            return None
 
     if Path(output_path).exists():
         # Optional ghostscript compression

--- a/colloquium/themes/default/presentation.js
+++ b/colloquium/themes/default/presentation.js
@@ -21,6 +21,7 @@ class ColloquiumPresentation {
 
         if (this.totalSlides === 0) return;
 
+        this.deck.setAttribute('tabindex', '-1');
         this.progressBar = document.querySelector('.colloquium-progress-bar');
         this.pickerTrigger = document.querySelector('.colloquium-picker-trigger');
         this.pickerTriggerCount = this.pickerTrigger
@@ -36,6 +37,7 @@ class ColloquiumPresentation {
         this._bindPickerTrigger();
         this._bindPresent();
         this._bindKeyboard();
+        this._bindIframes();
         this._bindClick();
         this._bindTouch();
         this._bindHashChange();
@@ -254,45 +256,90 @@ class ColloquiumPresentation {
 
     _bindKeyboard() {
         document.addEventListener('keydown', (e) => {
-            // Ignore if user is typing in an input
-            if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
-
-            switch (e.key) {
-                case 'ArrowRight':
-                case 'ArrowDown':
-                case ' ':
-                case 'PageDown':
-                    e.preventDefault();
-                    this.next();
-                    break;
-                case 'ArrowLeft':
-                case 'ArrowUp':
-                case 'PageUp':
-                    e.preventDefault();
-                    this.prev();
-                    break;
-                case 'Home':
-                    e.preventDefault();
-                    this.first();
-                    break;
-                case 'End':
-                    e.preventDefault();
-                    this.last();
-                    break;
-                case 'f':
-                case 'F':
-                    e.preventDefault();
-                    this._toggleFullscreen();
-                    break;
-                case 'Escape':
-                    if (this.pickerOpen) {
-                        this._closePicker();
-                    } else if (document.fullscreenElement) {
-                        document.exitFullscreen();
-                    }
-                    break;
-            }
+            if (this._isTextInputTarget(e.target)) return;
+            this._handleNavigationKey(e);
         });
+    }
+
+    _isTextInputTarget(target) {
+        if (!target || !target.tagName) return false;
+        if (target.isContentEditable) return true;
+        return ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName);
+    }
+
+    _handleNavigationKey(e) {
+        switch (e.key) {
+            case 'ArrowRight':
+            case 'ArrowDown':
+            case ' ':
+            case 'PageDown':
+                e.preventDefault();
+                this.next();
+                break;
+            case 'ArrowLeft':
+            case 'ArrowUp':
+            case 'PageUp':
+                e.preventDefault();
+                this.prev();
+                break;
+            case 'Home':
+                e.preventDefault();
+                this.first();
+                break;
+            case 'End':
+                e.preventDefault();
+                this.last();
+                break;
+            case 'f':
+            case 'F':
+                e.preventDefault();
+                this._toggleFullscreen();
+                break;
+            case 'Escape':
+                if (this.pickerOpen) {
+                    this._closePicker();
+                } else if (document.fullscreenElement) {
+                    document.exitFullscreen();
+                }
+                break;
+        }
+    }
+
+    _bindIframes() {
+        document.querySelectorAll('iframe.colloquium-iframe').forEach((iframe) => {
+            this._bindIframeKeyboardRelay(iframe);
+            iframe.addEventListener('load', () => this._bindIframeKeyboardRelay(iframe));
+            iframe.addEventListener('focus', () => this._recoverFocusFromIframe(iframe));
+        });
+    }
+
+    _bindIframeKeyboardRelay(iframe) {
+        if (iframe.dataset.colloquiumKeyboardRelayBound === 'true') return;
+
+        try {
+            const iframeDocument = iframe.contentWindow && iframe.contentWindow.document;
+            if (!iframeDocument) return;
+            iframeDocument.addEventListener('keydown', (e) => {
+                if (this._isTextInputTarget(e.target)) return;
+                this._handleNavigationKey(e);
+            });
+            iframe.dataset.colloquiumKeyboardRelayBound = 'true';
+        } catch (_) {
+            // Cross-origin frames cannot expose their keyboard events to the parent deck.
+        }
+    }
+
+    _recoverFocusFromIframe(iframe) {
+        if (iframe.dataset.colloquiumPreserveKeyboard === 'false') return;
+        if (iframe.dataset.colloquiumKeyboardRelayBound === 'true') return;
+
+        setTimeout(() => {
+            if (document.activeElement === iframe) {
+                iframe.blur();
+                window.focus();
+                this.deck.focus({ preventScroll: true });
+            }
+        }, 0);
     }
 
     _bindClick() {

--- a/colloquium/themes/default/presentation.js
+++ b/colloquium/themes/default/presentation.js
@@ -315,6 +315,8 @@ class ColloquiumPresentation {
     }
 
     _bindIframeKeyboardRelay(iframe) {
+        if (iframe.dataset.colloquiumPreserveKeyboard === 'false') return false;
+
         try {
             const iframeDocument = iframe.contentWindow && iframe.contentWindow.document;
             if (!iframeDocument) return false;

--- a/colloquium/themes/default/presentation.js
+++ b/colloquium/themes/default/presentation.js
@@ -9,6 +9,7 @@ class ColloquiumPresentation {
         this.slides = Array.from(document.querySelectorAll('.slide'));
         this.currentIndex = 0;
         this.totalSlides = this.slides.length;
+        this._iframeKeyboardRelayDocuments = new WeakSet();
 
         // Reference dimensions (16:9)
         this.width = 1280;
@@ -314,24 +315,26 @@ class ColloquiumPresentation {
     }
 
     _bindIframeKeyboardRelay(iframe) {
-        if (iframe.dataset.colloquiumKeyboardRelayBound === 'true') return;
-
         try {
             const iframeDocument = iframe.contentWindow && iframe.contentWindow.document;
-            if (!iframeDocument) return;
+            if (!iframeDocument) return false;
+            if (this._iframeKeyboardRelayDocuments.has(iframeDocument)) return true;
+
             iframeDocument.addEventListener('keydown', (e) => {
                 if (this._isTextInputTarget(e.target)) return;
                 this._handleNavigationKey(e);
             });
-            iframe.dataset.colloquiumKeyboardRelayBound = 'true';
+            this._iframeKeyboardRelayDocuments.add(iframeDocument);
+            return true;
         } catch (_) {
             // Cross-origin frames cannot expose their keyboard events to the parent deck.
+            return false;
         }
     }
 
     _recoverFocusFromIframe(iframe) {
         if (iframe.dataset.colloquiumPreserveKeyboard === 'false') return;
-        if (iframe.dataset.colloquiumKeyboardRelayBound === 'true') return;
+        if (this._bindIframeKeyboardRelay(iframe)) return;
 
         setTimeout(() => {
             if (document.activeElement === iframe) {

--- a/colloquium/themes/default/theme.css
+++ b/colloquium/themes/default/theme.css
@@ -191,6 +191,28 @@ html, body {
     display: block;
 }
 
+.colloquium-iframe-container {
+    max-width: 100%;
+}
+
+.colloquium-iframe {
+    display: block;
+    max-width: 100%;
+}
+
+.align-center.active .slide-content > .colloquium-iframe-container {
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.align-left.active .slide-content > .colloquium-iframe-container {
+    margin-right: auto;
+}
+
+.align-right.active .slide-content > .colloquium-iframe-container {
+    margin-left: auto;
+}
+
 .slide figure.colloquium-figure {
     margin: 0 auto 0.8em;
     max-width: 100%;

--- a/colloquium/themes/default/theme.css
+++ b/colloquium/themes/default/theme.css
@@ -200,16 +200,16 @@ html, body {
     max-width: 100%;
 }
 
-.align-center.active .slide-content > .colloquium-iframe-container {
+.align-center .slide-content > .colloquium-iframe-container {
     margin-left: auto;
     margin-right: auto;
 }
 
-.align-left.active .slide-content > .colloquium-iframe-container {
+.align-left .slide-content > .colloquium-iframe-container {
     margin-right: auto;
 }
 
-.align-right.active .slide-content > .colloquium-iframe-container {
+.align-right .slide-content > .colloquium-iframe-container {
     margin-left: auto;
 }
 

--- a/examples/hello/README.md
+++ b/examples/hello/README.md
@@ -13,3 +13,4 @@ Use it when you want one example that touches most of the default authoring surf
 - conversation blocks
 - box callouts
 - footnotes
+- iframe embeds

--- a/examples/hello/hello.md
+++ b/examples/hello/hello.md
@@ -384,11 +384,11 @@ The reward model is trained with the Bradley-Terry preference model, where $y_w$
 ## Embedded Web Content
 
 ```iframe
-src: https://www.interconnects.ai/embed
+src: https://www.interconnects.ai/embed?transparent=1
 width: 480
-height: 420
+height: 320
 title: Interconnects
-style: "border: 1px solid #EEE; background: white"
+style: "border: 0; background: transparent"
 frameborder: 0
 scrolling: no
 allowfullscreen: false

--- a/examples/hello/hello.md
+++ b/examples/hello/hello.md
@@ -379,6 +379,23 @@ The reward model is trained with the Bradley-Terry preference model, where $y_w$
 
 ---
 
+<!-- align: center -->
+
+## Embedded Web Content
+
+```iframe
+src: https://www.interconnects.ai/embed
+width: 480
+height: 320
+title: Interconnects
+style: "border: 1px solid #EEE; background: white"
+frameborder: 0
+scrolling: no
+allowfullscreen: false
+```
+
+---
+
 <!-- rows: 80/20 -->
 ## Thank You
 

--- a/examples/hello/hello.md
+++ b/examples/hello/hello.md
@@ -386,7 +386,7 @@ The reward model is trained with the Bradley-Terry preference model, where $y_w$
 ```iframe
 src: https://www.interconnects.ai/embed
 width: 480
-height: 320
+height: 420
 title: Interconnects
 style: "border: 1px solid #EEE; background: white"
 frameborder: 0

--- a/tests/elements/test_iframe.py
+++ b/tests/elements/test_iframe.py
@@ -87,10 +87,10 @@ def test_iframe_supports_embed_attributes():
     out = _render_iframe_block(
         "\n".join(
             [
-                "src: https://www.interconnects.ai/embed",
+                "src: https://www.interconnects.ai/embed?transparent=1",
                 "width: 480",
                 "height: 320",
-                'style: "border: 1px solid #EEE; background: white"',
+                'style: "border: 0; background: transparent"',
                 "frameborder: 0",
                 "scrolling: no",
             ]
@@ -100,4 +100,4 @@ def test_iframe_supports_embed_attributes():
     assert 'height="320"' in out
     assert 'frameborder="0"' in out
     assert 'scrolling="no"' in out
-    assert 'style="border: 1px solid #EEE; background: white"' in out
+    assert 'style="border: 0; background: transparent"' in out

--- a/tests/elements/test_iframe.py
+++ b/tests/elements/test_iframe.py
@@ -1,5 +1,3 @@
-import re
-
 from colloquium.elements.iframe import PATTERN, process
 
 
@@ -22,6 +20,7 @@ def test_iframe_renders_optional_fields():
         "\n".join(
             [
                 "src: https://example.com/x",
+                "width: 480",
                 "height: 520",
                 "title: Demo Frame",
                 "loading: eager",
@@ -29,6 +28,7 @@ def test_iframe_renders_optional_fields():
             ]
         )
     )
+    assert 'width="480"' in out
     assert 'height="520"' in out
     assert 'title="Demo Frame"' in out
     assert 'loading="eager"' in out
@@ -50,6 +50,12 @@ def test_iframe_requires_src():
     assert "Iframe requires src" in out
 
 
+def test_iframe_rejects_null_src():
+    out = _render_iframe_block("src: null")
+    assert "Iframe requires src" in out
+    assert 'src="None"' not in out
+
+
 def test_iframe_sanitizes_src_and_title():
     out = _render_iframe_block(
         "\n".join(
@@ -67,3 +73,28 @@ def test_iframe_height_falls_back_to_default_for_invalid_values():
     for bad in ["0", "-10", "abc"]:
         out = _render_iframe_block(f"src: https://example.com\nheight: {bad}")
         assert 'height="480"' in out
+
+
+def test_iframe_loading_falls_back_to_default_for_invalid_values():
+    out = _render_iframe_block("src: https://example.com\nloading: banana")
+    assert 'loading="lazy"' in out
+
+
+def test_iframe_supports_embed_attributes():
+    out = _render_iframe_block(
+        "\n".join(
+            [
+                "src: https://www.interconnects.ai/embed",
+                "width: 480",
+                "height: 320",
+                'style: "border: 1px solid #EEE; background: white"',
+                "frameborder: 0",
+                "scrolling: no",
+            ]
+        )
+    )
+    assert 'width="480"' in out
+    assert 'height="320"' in out
+    assert 'frameborder="0"' in out
+    assert 'scrolling="no"' in out
+    assert 'style="border: 1px solid #EEE; background: white"' in out

--- a/tests/elements/test_iframe.py
+++ b/tests/elements/test_iframe.py
@@ -1,0 +1,69 @@
+import re
+
+from colloquium.elements.iframe import PATTERN, process
+
+
+def _render_iframe_block(yaml_body: str) -> str:
+    html = f'<pre><code class="language-iframe">{yaml_body}</code></pre>'
+    return PATTERN.sub(lambda m: process(m.group(1)), html)
+
+
+def test_iframe_renders_with_required_src():
+    out = _render_iframe_block("src: https://example.com/embed.html")
+    assert '<iframe' in out
+    assert 'src="https://example.com/embed.html"' in out
+    assert 'height="480"' in out  # default
+    assert 'loading="lazy"' in out  # default
+    assert 'allowfullscreen' in out
+
+
+def test_iframe_renders_optional_fields():
+    out = _render_iframe_block(
+        "\n".join(
+            [
+                "src: https://example.com/x",
+                "height: 520",
+                "title: Demo Frame",
+                "loading: eager",
+                "allowfullscreen: false",
+            ]
+        )
+    )
+    assert 'height="520"' in out
+    assert 'title="Demo Frame"' in out
+    assert 'loading="eager"' in out
+    assert 'allowfullscreen' not in out
+
+
+def test_iframe_invalid_yaml():
+    out = _render_iframe_block("src: [not valid")
+    assert "Invalid iframe YAML" in out
+
+
+def test_iframe_requires_mapping():
+    out = _render_iframe_block("- src: https://example.com")
+    assert "Iframe spec must be a YAML mapping" in out
+
+
+def test_iframe_requires_src():
+    out = _render_iframe_block("height: 500")
+    assert "Iframe requires src" in out
+
+
+def test_iframe_sanitizes_src_and_title():
+    out = _render_iframe_block(
+        "\n".join(
+            [
+                'src: https://example.com/?q="x"&k=<tag>',
+                'title: "<unsafe>"',
+            ]
+        )
+    )
+    assert 'src="https://example.com/?q=&quot;x&quot;&amp;k=&lt;tag&gt;"' in out
+    assert 'title="&lt;unsafe&gt;"' in out
+
+
+def test_iframe_height_falls_back_to_default_for_invalid_values():
+    for bad in ["0", "-10", "abc"]:
+        out = _render_iframe_block(f"src: https://example.com\nheight: {bad}")
+        assert 'height="480"' in out

--- a/tests/elements/test_iframe.py
+++ b/tests/elements/test_iframe.py
@@ -11,8 +11,9 @@ def test_iframe_renders_with_required_src():
     assert '<iframe' in out
     assert 'src="https://example.com/embed.html"' in out
     assert 'height="480"' in out  # default
-    assert 'loading="lazy"' in out  # default
+    assert 'loading="eager"' in out  # default
     assert 'allowfullscreen' in out
+    assert 'data-colloquium-preserve-keyboard="true"' in out
 
 
 def test_iframe_renders_optional_fields():
@@ -23,16 +24,18 @@ def test_iframe_renders_optional_fields():
                 "width: 480",
                 "height: 520",
                 "title: Demo Frame",
-                "loading: eager",
+                "loading: lazy",
                 "allowfullscreen: false",
+                "preserve_keyboard: false",
             ]
         )
     )
     assert 'width="480"' in out
     assert 'height="520"' in out
     assert 'title="Demo Frame"' in out
-    assert 'loading="eager"' in out
+    assert 'loading="lazy"' in out
     assert 'allowfullscreen' not in out
+    assert 'data-colloquium-preserve-keyboard="false"' in out
 
 
 def test_iframe_invalid_yaml():
@@ -77,7 +80,7 @@ def test_iframe_height_falls_back_to_default_for_invalid_values():
 
 def test_iframe_loading_falls_back_to_default_for_invalid_values():
     out = _render_iframe_block("src: https://example.com\nloading: banana")
-    assert 'loading="lazy"' in out
+    assert 'loading="eager"' in out
 
 
 def test_iframe_supports_embed_attributes():

--- a/tests/test_pdf_export.py
+++ b/tests/test_pdf_export.py
@@ -1,0 +1,16 @@
+from urllib.request import urlopen
+
+from colloquium.export import _serve_html_for_export
+
+
+def test_serve_html_for_export_serves_deck_over_loopback(tmp_path):
+    html_path = tmp_path / "deck file.html"
+    html_path.write_text("<!doctype html><title>Deck</title>", encoding="utf-8")
+
+    with _serve_html_for_export(str(html_path)) as url:
+        assert url.startswith("http://127.0.0.1:")
+        assert url.endswith("/deck%20file.html")
+        with urlopen(url, timeout=2) as response:
+            body = response.read().decode("utf-8")
+
+    assert "<title>Deck</title>" in body


### PR DESCRIPTION
## Summary
 
Adds a built-in `iframe` fenced element to Colloquium so slide authors can embed external/local HTML content. Uses the YAML-block grammar as existing elements (`box`, `chart`, `conversation`).
 
## Changes

1. Added new element module: `colloquium/elements/iframe.py`
2. Registered iframe in `colloquium/elements/__init__.py`:
  - included in `ELEMENTS`
  - included in `reset()` contract
3. Added tests: `tests/elements/test_iframe.py`

 ## New syntax
 
 ```iframe
 src: https://example.com/embed.html
 height: 520
 title: Demo frame
 loading: lazy
 allowfullscreen: true
 ```
 
| Field | Required | Type | Allowed values | Default | Notes |
|---|---|---|---|---|---|
| `src` | Yes | string | Any non-empty URL or path | — | Source loaded by the iframe. |
| `height` | No | integer | Positive integer (`> 0`) | `480` | Invalid or non-positive values fall back to `480`. |
| `title` | No | string | Any string | `""` | Sets iframe `title` attribute for accessibility. |
| `loading` | No | string | `lazy` or `eager` | `lazy` | `lazy`: load when near visible area; lower initial load cost. `eager`: load immediately; faster iframe readiness but more upfront requests. |
| `allowfullscreen` | No | boolean/string | `true`/`false` (`false`, `"false"`, `"off"`, `"0"` disable) | `true` | If enabled, emits the `allowfullscreen` attribute. |

## Behavior

- `src` is required.
- `height` defaults to `480` and falls back to default for invalid/non-positive values.
- Output is escaped/sanitized for safe HTML attribute rendering.
- `allowfullscreen` defaults to enabled; can be disabled via YAML.


## Tests added

`tests/elements/test_iframe.py` includes:
 
| Name | Description | Purpose |
|---|---|---|
| `test_iframe_renders_with_required_src` | Renders iframe with only required `src` field. | Confirms baseline render path and defaults are applied. |
| `test_iframe_renders_optional_fields` | Renders iframe with `height`, `title`, `loading`, and `allowfullscreen`. | Verifies optional arguments are parsed and emitted correctly. |
| `test_iframe_invalid_yaml` | Passes malformed YAML. | Ensures parser errors return clear user-facing error markup. |
| `test_iframe_requires_mapping` | Passes YAML list instead of mapping/object. | Enforces expected YAML object structure. |
| `test_iframe_requires_src` | Omits `src`. | Confirms required-field validation. |
| `test_iframe_sanitizes_src_and_title` | Uses special characters in `src` and `title`. | Verifies HTML escaping/sanitization of output attributes. |
| `test_iframe_height_falls_back_to_default_for_invalid_values` | Uses invalid/non-positive `height` values. | Confirms robust fallback to default height (`480`). |

All iframe tests pass locally.

## Purpose

Motivation was the ability to embed visualizations with interactive components without monkey-patching support.
Makes iframe authoring a documented Colloquium feature.

## Issue

Once a user interacts with an iframe (click, drag, scroll), keyboard focus moves from the parent deck to the iframe document. The deck’s keydown handlers (Arrow keys → next/previous slide) stop receiving those events unless key events are explicitly relayed or focus is returned to the parent. Mouse navigation at the slide edges can still advance slides, bu keyboard navigation remains unavailable until focus is restored.

```text
 Before click:
 Keyboard -> Parent document/window keydown listener -> slide nav (next/prev)
 
 After iframe click:
 Keyboard -> Iframe document keydown listener/context -X-> parent slide listener
 ```

## Future work (follow-up PR)
 
 - Update `themes/default/presentation.js` so keyboard navigation still works after clicking
 inside an iframe.
 - Add an end-to-end Playwright test that reproduces this behavior and prevents regressions.
 - Add a safety test for cross-origin iframes to confirm the deck does not error or crash.
 
 ## Proposed implementation
 
 1. In the presentation runtime, find iframe elements used by the new iframe feature.
 2. When an iframe loads, try to listen for `keydown` events inside that iframe.
 3. When a key is pressed inside the iframe, forward that key event to the parent deck 
window.
 4. If the iframe is cross-origin and browser security blocks access, catch that error and 
skip forwarding (no-op).
 
 ## Test plan (future)
 
 1. Create a small fixture deck with a same-origin iframe page.
 2. In Playwright: open the deck, click inside the iframe, press `ArrowRight`, and verify 
the slide advances.
 3. Add a control check showing behavior without relay does not advance on keyboard input 
from iframe focus.
 4. Add a cross-origin iframe fixture and verify there are no runtime errors/crashes.