### PR TITLE
Fix block animation for generated elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ One line per PR for easy copy into GitHub releases.
 
 ## [Unreleased]
 
+- Fix block animations for generated div-based elements ([#33](https://github.com/natolambert/colloquium/pull/33))
 - Bind dev server to loopback, change default port to 8090, and error on port conflicts ([#28](https://github.com/natolambert/colloquium/pull/28))
 - Upgrade locked Pillow to 12.2.0 to fix CVE-2026-40192 ([#29](https://github.com/natolambert/colloquium/pull/29))
 - Upgrade locked pytest to 9.0.3 and Pygments to 2.20.0 to fix CVE-2025-71176 and CVE-2026-4539 ([#30](https://github.com/natolambert/colloquium/pull/30))

--- a/colloquium/build.py
+++ b/colloquium/build.py
@@ -110,6 +110,7 @@ _FRAGMENT_BLOCK_TAGS = frozenset(
         "blockquote",
         "table",
         "figure",
+        "div",
     )
 )
 

--- a/colloquium/build.py
+++ b/colloquium/build.py
@@ -95,6 +95,7 @@ _STEP_MARKER_RE = re.compile(r"\s*<!--\s*step\s*-->\s*")
 _CLASS_ATTR_RE = re.compile(r'\sclass=(["\'])(.*?)\1')
 _LI_TAG_RE = re.compile(r"<li\b([^>]*)>")
 _GENERATED_FRAGMENT_RE = re.compile(r'\sdata-colloquium-fragment="1"')
+_EMPTY_DIV_RE = re.compile(r"<div\b([^>]*)>\s*</div>", re.DOTALL)
 _FRAGMENT_BLOCK_TAGS = frozenset(
     (
         "h1",
@@ -118,6 +119,17 @@ _FRAGMENT_BLOCK_TAGS = frozenset(
 def _wrap_fragment_html(content: str) -> str:
     """Wrap *content* in a generated fragment container."""
     return f'<div class="fragment" data-colloquium-fragment="1">{content}</div>'
+
+
+def _is_spacer_only_div(html: str) -> bool:
+    """Return True for empty spacer helper divs that should not consume a step."""
+    match = _EMPTY_DIV_RE.fullmatch(html.strip())
+    if not match:
+        return False
+    class_match = _CLASS_ATTR_RE.search(match.group(1))
+    if not class_match:
+        return False
+    return any(cls.startswith("colloquium-spacer-") for cls in class_match.group(2).split())
 
 
 def _contains_generated_fragments(html: str) -> bool:
@@ -181,7 +193,10 @@ def _wrap_blocks_as_fragments(
             block_html = "\n".join(current)
             stripped = block_html.strip()
             if stripped:
-                if preserve_column_markers and stripped == "<p>|||</p>":
+                if (
+                    (preserve_column_markers and stripped == "<p>|||</p>")
+                    or _is_spacer_only_div(stripped)
+                ):
                     blocks.append(block_html)
                 else:
                     blocks.append(_wrap_fragment_html(block_html))
@@ -189,8 +204,12 @@ def _wrap_blocks_as_fragments(
 
     if current:
         block_html = "\n".join(current)
-        if block_html.strip():
-            blocks.append(_wrap_fragment_html(block_html))
+        stripped = block_html.strip()
+        if stripped:
+            if _is_spacer_only_div(stripped):
+                blocks.append(block_html)
+            else:
+                blocks.append(_wrap_fragment_html(block_html))
 
     return "\n".join(blocks)
 
@@ -255,6 +274,10 @@ def _wrap_non_fragment_blocks(html: str) -> str:
     def _emit_block(block_html: str) -> None:
         stripped = block_html.strip()
         if not stripped:
+            return
+        # Spacer helper divs are layout-only; revealing them would be a blank click.
+        if _is_spacer_only_div(stripped):
+            blocks.append(block_html)
             return
         # Already a fragment wrapper div — skip
         if stripped.startswith('<div class="fragment" data-colloquium-fragment="1">'):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1719,6 +1719,33 @@ class TestFragments:
             '<div class="colloquium-iframe-container"'
         ) in html
 
+    def test_blocks_skip_spacer_only_divs(self):
+        """Layout spacer divs should not consume empty reveal steps."""
+        deck = Deck(title="Test")
+        slide = Slide(
+            title="Spacer",
+            content=(
+                "Before\n\n"
+                '<div class="colloquium-spacer-md"></div>\n\n'
+                "```box\n"
+                "title: Key result\n"
+                "content: Generated box\n"
+                "```"
+            ),
+            metadata={"animate": "blocks"},
+        )
+        deck.slides.append(slide)
+
+        html = build_deck(deck)
+
+        assert 'data-fragment-count="2"' in html
+        assert (
+            '<div class="fragment" data-fragment-index="1"><p>Before</p></div>\n'
+            '<div class="colloquium-spacer-md"></div>\n'
+            '<div class="fragment" data-fragment-index="2">'
+            '<div class="colloquium-box'
+        ) in html
+
     def test_step_with_columns_preserves_column_boundaries(self):
         """Step fragments in a column must not wrap sibling column divs."""
         deck = Deck(title="Test")

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1668,6 +1668,57 @@ class TestFragments:
             '<p>Details.</p></div>'
         ) in html
 
+    def test_blocks_wrap_generated_div_elements(self):
+        """Blocks mode must reveal built-in div-based elements incrementally."""
+        deck = Deck(title="Test")
+        slide = Slide(
+            title="Generated",
+            content=(
+                "```box\n"
+                "title: Key result\n"
+                "content: Generated box\n"
+                "```\n\n"
+                "```chart\n"
+                "type: bar\n"
+                "data:\n"
+                "  labels: [A]\n"
+                "  datasets:\n"
+                "    - label: Score\n"
+                "      data: [1]\n"
+                "```\n\n"
+                "```conversation\n"
+                "messages:\n"
+                "  - role: user\n"
+                "    content: Hello\n"
+                "```\n\n"
+                "```iframe\n"
+                "src: https://example.com/embed.html\n"
+                "```"
+            ),
+            metadata={"animate": "blocks"},
+        )
+        deck.slides.append(slide)
+
+        html = build_deck(deck)
+
+        assert 'data-fragment-count="4"' in html
+        assert (
+            '<div class="fragment" data-fragment-index="1">'
+            '<div class="colloquium-box'
+        ) in html
+        assert (
+            '<div class="fragment" data-fragment-index="2">'
+            '<div class="colloquium-chart-container">'
+        ) in html
+        assert (
+            '<div class="fragment" data-fragment-index="3">'
+            '<div class="colloquium-conversation"'
+        ) in html
+        assert (
+            '<div class="fragment" data-fragment-index="4">'
+            '<div class="colloquium-iframe-container"'
+        ) in html
+
     def test_step_with_columns_preserves_column_boundaries(self):
         """Step fragments in a column must not wrap sibling column divs."""
         deck = Deck(title="Test")


### PR DESCRIPTION
## Summary
- Treat top-level generated div elements as block fragments for animate: blocks
- Add regression coverage for box, chart, conversation, and iframe elements

## Tests
- UV_CACHE_DIR=.uv-cache uv run --extra dev pytest tests/test_build.py::TestFragments
- UV_CACHE_DIR=.uv-cache uv run pytest