### PR TITLE
Support slides after references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ One line per PR for easy copy into GitHub releases.
 - Upgrade locked lxml to 6.1.0 to fix CVE-2026-41066 (XXE in iterparse/ETCompatXMLParser) ([#31](https://github.com/natolambert/colloquium/pull/31))
 - Add a built-in iframe element for embedding external or local HTML content ([#32](https://github.com/natolambert/colloquium/pull/32))
 - Add fragment-based animations: `<!-- animate: bullets|blocks -->` and `<!-- step -->` for incremental reveal ([#25](https://github.com/natolambert/colloquium/pull/25))
+- Add `<!-- after: references -->` for post-reference appendix slides excluded from the footer total ([#34](https://github.com/natolambert/colloquium/pull/34))
 
 ## [0.2.1] - 2026-03-25
 

--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ At the slide root, use either `columns:` or `rows:`. For nested layouts, use `ro
 | `<!-- class: name1 name2 -->` | Add CSS classes to the slide |
 | `<!-- style: css-here -->` | Inline CSS on the slide element |
 | `<!-- notes: text -->` | Speaker notes (hidden in presentation) |
+| `<!-- after: references -->` | Move this slide after generated bibliography slides; it is excluded from the footer `{N}` total |
 | `<!-- class: figure-captions -->` | Turn standalone markdown images on that slide into numbered figures with captions taken from `![alt](...)` |
 | `<!-- class: no-figure-captions -->` | Disable deck-wide figure captions for a specific slide |
 | `<!-- img-align: center -->` | Align images only (`left`, `center`, `right`) — title unaffected |
@@ -292,6 +293,20 @@ citation_order: auto
 - `citation_style: numeric` keeps citations and references in first-appearance order.
 - Non-numeric styles default to alphabetical ordering.
 - Set `citation_order: appearance` to keep author-year or title-year citations in source order.
+
+To add appendix or backup slides after the automatically generated references, place them at the end of the markdown and add a slide directive:
+
+```markdown
+---
+
+<!-- after: references -->
+
+## Backup analysis
+
+Extra material
+```
+
+These post-reference slides render after the references section, but they do not contribute to the footer `{N}` total. If the main talk plus generated references totals 30 slides, the first post-reference slide is numbered `31/30`.
 
 ## Content Features
 

--- a/colloquium/build.py
+++ b/colloquium/build.py
@@ -1498,9 +1498,18 @@ def build_deck(deck: Deck) -> str:
     citation_order = deck.citation_order
     citation_numbers: dict[str, int] = {}
 
+    main_slides = [
+        slide for slide in deck.slides
+        if slide.metadata.get("after") != "references"
+    ]
+    post_reference_slides = [
+        slide for slide in deck.slides
+        if slide.metadata.get("after") == "references"
+    ]
+
     # First pass: build slides and discover cited keys
     cited_keys: list[str] = []
-    total = len(deck.slides)
+    total = len(main_slides)
 
     # If we have bib entries, we need a two-pass approach:
     # first discover citations, then rebuild with correct total (including references slide)
@@ -1524,13 +1533,13 @@ def build_deck(deck: Deck) -> str:
             cited_keys, bib_entries, citation_style, citation_order, citation_numbers,
         )
         if ref_slide_count:
-            total = len(deck.slides) + ref_slide_count
+            total = len(main_slides) + ref_slide_count
 
         # Reset counters for the real build pass
         elements.reset()
 
     slides_html_parts = []
-    for i, slide in enumerate(deck.slides):
+    for i, slide in enumerate(main_slides):
         slide_html = _build_slide_html(
             slide, i, total, md, deck.footer,
             bib_entries=bib_entries,
@@ -1550,9 +1559,30 @@ def build_deck(deck: Deck) -> str:
     if bib_entries and cited_keys:
         ref_slides = _build_references_slides_html(
             bib_entries, cited_keys, citation_style,
-            len(deck.slides), total, deck.footer, citation_order, citation_numbers,
+            len(main_slides), total, deck.footer, citation_order, citation_numbers,
         )
         slides_html_parts.extend(ref_slides)
+
+    post_reference_start = len(main_slides)
+    if bib_entries and cited_keys:
+        post_reference_start += _count_references_slides(
+            cited_keys, bib_entries, citation_style, citation_order, citation_numbers,
+        )
+    for offset, slide in enumerate(post_reference_slides):
+        slide_html = _build_slide_html(
+            slide, post_reference_start + offset, total, md, deck.footer,
+            bib_entries=bib_entries,
+            citation_style=citation_style,
+            cited_keys=cited_keys,
+            citation_order=citation_order,
+            citation_numbers=citation_numbers,
+            deck_figure_captions=deck.figure_captions,
+        )
+        if bib_entries:
+            slide_html = _process_citations(
+                slide_html, bib_entries, citation_style, cited_keys, citation_order, citation_numbers,
+            )
+        slides_html_parts.append(slide_html)
 
     slides_html = "\n\n".join(slides_html_parts)
 

--- a/colloquium/build.py
+++ b/colloquium/build.py
@@ -1506,6 +1506,7 @@ def build_deck(deck: Deck) -> str:
         slide for slide in deck.slides
         if slide.metadata.get("after") == "references"
     ]
+    render_order_slides = main_slides + post_reference_slides
 
     # First pass: build slides and discover cited keys
     cited_keys: list[str] = []
@@ -1515,7 +1516,7 @@ def build_deck(deck: Deck) -> str:
     # first discover citations, then rebuild with correct total (including references slide)
     if bib_entries:
         # Discovery pass — render slides to find cited keys
-        for slide in deck.slides:
+        for slide in render_order_slides:
             if slide.content:
                 rendered = _render_markdown(slide.content, md)
                 _discover_citation_keys(rendered, bib_entries, cited_keys)

--- a/colloquium/parse.py
+++ b/colloquium/parse.py
@@ -12,7 +12,7 @@ from colloquium.slide import Slide
 
 # Directive patterns: <!-- key: value -->
 _DIRECTIVE_RE = re.compile(
-    r"<!--\s*(layout|class|style|notes|title|align|valign|columns|rows|padding|size|cite|cite-left|cite-right|footnote|footnote-right|footnotes|img-align|img-valign|img-fill|img-overflow|animate)\s*:\s*(.*?)\s*-->",
+    r"<!--\s*(layout|class|style|notes|title|align|valign|columns|rows|padding|size|cite|cite-left|cite-right|footnote|footnote-right|footnotes|img-align|img-valign|img-fill|img-overflow|animate|after)\s*:\s*(.*?)\s*-->",
     re.DOTALL,
 )
 
@@ -109,6 +109,8 @@ def parse_slide(text: str) -> Slide:
                 metadata["footnotes_position"] = value
         elif key == "animate":
             metadata["animate"] = value
+        elif key == "after":
+            metadata["after"] = value
         elif key == "columns":
             spec = _normalize_grid_spec(value)
             if spec:

--- a/docs/build.py
+++ b/docs/build.py
@@ -347,6 +347,7 @@ uv run colloquium export examples/hello/hello.md  # export PDF via Chromium</cod
         <li>Markdown native</li>
         <li>Equations and code highlighting</li>
         <li>BibTeX via Pybtex</li>
+        <li>Post-reference appendix slides</li>
         <li>Charts</li>
       </ul>
       <p class="muted">More coming soon.</p>

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1264,6 +1264,26 @@ class TestCitationRendering:
             assert "colloquium-slide-meta--left" in html
             assert "Smith" in html
 
+    def test_after_references_slides_render_after_generated_references(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bib_path = self._make_bib(tmpdir)
+            deck = Deck(title="Test", bibliography=bib_path)
+            deck.slides.append(Slide(title="Intro", content="See [@smith2024]."))
+            deck.slides.append(
+                Slide(
+                    title="Appendix",
+                    content="Extra plot.",
+                    metadata={"after": "references"},
+                )
+            )
+
+            html = build_deck(deck)
+
+            assert html.index("<h2>Intro</h2>") < html.index("<h2>References</h2>")
+            assert html.index("<h2>References</h2>") < html.index("<h2>Appendix</h2>")
+            assert 'data-index="2"' in html[html.index("<h2>Appendix</h2>") - 80:html.index("<h2>Appendix</h2>")]
+            assert "3 / 2" in html
+
     def test_per_slide_cite_right_renders(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             bib_path = self._make_bib(tmpdir)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1284,6 +1284,32 @@ class TestCitationRendering:
             assert 'data-index="2"' in html[html.index("<h2>Appendix</h2>") - 80:html.index("<h2>Appendix</h2>")]
             assert "3 / 2" in html
 
+    def test_after_references_citations_use_render_order(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bib_path = self._make_bib(tmpdir)
+            deck = Deck(title="Test", bibliography=bib_path, citation_style="numeric")
+            deck.slides.append(
+                Slide(
+                    title="Appendix",
+                    content="Appendix cites [@jones2023].",
+                    metadata={"after": "references"},
+                )
+            )
+            deck.slides.append(Slide(title="Main", content="Main cites [@smith2024]."))
+
+            html = build_deck(deck)
+
+            main_start = html.index("<h2>Main</h2>")
+            references_start = html.index("<h2>References</h2>")
+            appendix_start = html.index("<h2>Appendix</h2>")
+            main_html = html[main_start:references_start]
+            references_html = html[references_start:appendix_start]
+            appendix_html = html[appendix_start:]
+
+            assert "[1]" in main_html
+            assert "[2]" in appendix_html
+            assert references_html.index("Smith") < references_html.index("Jones")
+
     def test_per_slide_cite_right_renders(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             bib_path = self._make_bib(tmpdir)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -189,6 +189,11 @@ class TestParseSlide:
         slide = parse_slide(text)
         assert "size-small" in slide.classes
 
+    def test_after_references_directive(self):
+        text = "<!-- after: references -->\n## Appendix\n\nExtra material"
+        slide = parse_slide(text)
+        assert slide.metadata.get("after") == "references"
+
     def test_img_overflow_directive(self):
         text = "<!-- img-overflow: true -->\n## Slide\n\n![Alt](figure.png)"
         slide = parse_slide(text)


### PR DESCRIPTION
Adds an `<!-- after: references -->` slide directive for appendix material that should render after generated bibliography slides. These post-reference slides are excluded from the footer total `{N}`, so they behave as extra slides after the main talk count.\n\nTests: `uv run --with pytest pytest tests/test_parse.py tests/test_build.py -q`