### PR TITLE
[codex] Hide mobile picker trigger in embedded decks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ One line per PR for easy copy into GitHub releases.
 - Upgrade locked lxml to 6.1.0 to fix CVE-2026-41066 (XXE in iterparse/ETCompatXMLParser) ([#31](https://github.com/natolambert/colloquium/pull/31))
 - Add a built-in iframe element for embedding external or local HTML content ([#32](https://github.com/natolambert/colloquium/pull/32))
 - Add fragment-based animations: `<!-- animate: bullets|blocks -->` and `<!-- step -->` for incremental reveal ([#25](https://github.com/natolambert/colloquium/pull/25))
+- Hide the mobile slide picker trigger when decks are embedded in iframes ([#35](https://github.com/natolambert/colloquium/pull/35))
 
 ## [0.2.1] - 2026-03-25
 

--- a/colloquium/themes/default/presentation.js
+++ b/colloquium/themes/default/presentation.js
@@ -11,6 +11,10 @@ class ColloquiumPresentation {
         this.totalSlides = this.slides.length;
         this._iframeKeyboardRelayDocuments = new WeakSet();
 
+        if (this._isEmbedded()) {
+            document.body.classList.add('colloquium-embedded');
+        }
+
         // Fragment state: current revealed fragment index per slide (0 = none)
         this.fragmentStates = this.slides.map(() => 0);
         this.fragmentCounts = this.slides.map(
@@ -55,6 +59,14 @@ class ColloquiumPresentation {
             this.goTo(hash - 1);
         } else {
             this.goTo(0);
+        }
+    }
+
+    _isEmbedded() {
+        try {
+            return window.self !== window.top;
+        } catch (_) {
+            return true;
         }
     }
 

--- a/colloquium/themes/default/theme.css
+++ b/colloquium/themes/default/theme.css
@@ -1148,6 +1148,10 @@ html, body {
     color: var(--colloquium-accent);
 }
 
+body.colloquium-embedded .colloquium-picker-trigger {
+    display: none !important;
+}
+
 /* ===== Present Button ===== */
 .colloquium-present {
     position: fixed;
@@ -1701,6 +1705,7 @@ body:hover .colloquium-present {
 .colloquium-capture .colloquium-present,
 .colloquium-capture .colloquium-progress,
 .colloquium-capture .colloquium-overflow-warn,
+.colloquium-capture .colloquium-picker-trigger,
 .colloquium-capture .colloquium-picker-overlay {
     display: none !important;
 }


### PR DESCRIPTION
## Summary
- Detect when a colloquium deck is running inside an iframe and add a `colloquium-embedded` body class.
- Hide the mobile picker trigger for embedded decks so preview cards do not show the large `SLIDES 1 / N` pill.
- Also hide the picker trigger in capture mode, matching the rest of the presentation chrome.
- Add the required changelog entry under `Unreleased`.

## Validation
- `uv run pytest tests/test_build.py tests/test_parse.py`
- `uv run python -m colloquium.cli build /Users/nato/Documents/home/me/new-homepage/slides/china-atom-2026/talk.md -o /tmp/china-atom-local-colloquium-check`