### PR TITLE
Fix: title:center no longer centers the whole slide body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ One line per PR for easy copy into GitHub releases.
 
 ## [Unreleased]
 
+- Fix `title: center` leaking center alignment to the whole slide body, and citation author surnames (keep full multi-word names, strip BibTeX braces) ([#36](https://github.com/natolambert/colloquium/pull/36))
 - Fix block animations for generated div-based elements ([#33](https://github.com/natolambert/colloquium/pull/33))
 - Bind dev server to loopback, change default port to 8090, and error on port conflicts ([#28](https://github.com/natolambert/colloquium/pull/28))
 - Upgrade locked Pillow to 12.2.0 to fix CVE-2026-40192 ([#29](https://github.com/natolambert/colloquium/pull/29))

--- a/colloquium/build.py
+++ b/colloquium/build.py
@@ -408,17 +408,27 @@ def _parse_bib_file(path: str) -> dict:
         return {}
 
 
+def _person_surname(person) -> str:
+    """Full last name of a pybtex Person: join multi-word names, drop BibTeX braces.
+
+    pybtex splits an unprotected "Ben Allal" into ["Ben", "Allal"] (so taking only
+    the first token drops "Allal"), and keeps the braces from a protected
+    "{Ben Allal}" (so it renders literally). Joining the parts and normalizing
+    handles both.
+    """
+    surnames = person.last_names
+    if surnames:
+        return _normalize_bibtex_field(" ".join(surnames))
+    return _normalize_bibtex_field(str(person))
+
+
 def _get_author_surname(entry) -> str:
     """Extract the first author's surname from a pybtex entry."""
     try:
         persons = entry.persons.get("author", [])
         if not persons:
             return "Unknown"
-        first = persons[0]
-        surnames = first.last_names
-        if surnames:
-            return surnames[0]
-        return str(first)
+        return _person_surname(persons[0])
     except Exception:
         return "Unknown"
 
@@ -500,9 +510,7 @@ def _format_citation_label(entry, key: str, style: str, number: int) -> str:
         if len(authors) > 2:
             surname += " et al."
         elif len(authors) == 2:
-            second = authors[1].last_names
-            if second:
-                surname += f" & {second[0]}"
+            surname += f" & {_person_surname(authors[1])}"
         return f"{surname}, {_get_year(entry)}"
 
 
@@ -624,7 +632,7 @@ def _format_reference(entry, key: str, style: str, number: int) -> str:
     authors = entry.persons.get("author", [])
     author_strs = []
     for person in authors:
-        surnames = " ".join(person.last_names)
+        surnames = _person_surname(person)
         firsts = " ".join(n[0] + "." for n in person.first_names if n) if person.first_names else ""
         if firsts:
             author_strs.append(f"{surnames}, {firsts}")

--- a/colloquium/themes/default/theme.css
+++ b/colloquium/themes/default/theme.css
@@ -679,7 +679,8 @@ html, body {
 
 /* ===== Utility: Title Position ===== */
 .title-top.active { justify-content: flex-start; }
-.title-center.active { justify-content: center; align-items: center; text-align: center; }
+.title-center.active { justify-content: center; }
+.title-center.active h1, .title-center.active h2 { text-align: center; }
 .title-hidden h1, .title-hidden h2 { display: none; }
 
 /* ===== Utility: Text Alignment ===== */
@@ -1628,7 +1629,8 @@ body:hover .colloquium-present {
     }
 
     .title-top { justify-content: flex-start; }
-    .title-center { justify-content: center; align-items: center; text-align: center; }
+    .title-center { justify-content: center; }
+    .title-center h1, .title-center h2 { text-align: center; }
 
     .align-left { text-align: left; }
     .align-center { text-align: center; }

--- a/colloquium/themes/default/theme.css
+++ b/colloquium/themes/default/theme.css
@@ -680,7 +680,7 @@ html, body {
 /* ===== Utility: Title Position ===== */
 .title-top.active { justify-content: flex-start; }
 .title-center.active { justify-content: center; }
-.title-center.active h1, .title-center.active h2 { text-align: center; }
+.title-center.active > h1, .title-center.active > h2 { text-align: center; }
 .title-hidden h1, .title-hidden h2 { display: none; }
 
 /* ===== Utility: Text Alignment ===== */
@@ -1630,7 +1630,7 @@ body:hover .colloquium-present {
 
     .title-top { justify-content: flex-start; }
     .title-center { justify-content: center; }
-    .title-center h1, .title-center h2 { text-align: center; }
+    .title-center > h1, .title-center > h2 { text-align: center; }
 
     .align-left { text-align: left; }
     .align-center { text-align: center; }


### PR DESCRIPTION
Two related theme/formatter fixes.

## 1. `title: center` no longer centers the whole slide body

`<!-- title: center -->` maps to `.title-center`, in the **"Utility: Title Position"** section of `theme.css` — meant to control *where the title sits*. But unlike `.title-top` (which only touches `justify-content`), `.title-center` also set `align-items: center` and `text-align: center` on the `.slide` flex container, so every paragraph, equation, and list inherited center alignment. Decks needed workaround CSS (`.slide ul, li { text-align: left }`) to undo the leak.

Fix — scope the centering to the title element:

```css
.title-center.active { justify-content: center; }
.title-center.active h1, .title-center.active h2 { text-align: center; }
```

Applied to both the desktop rule and the mobile media-query duplicate.

## 2. Citation author names: full surnames, no stray braces

The inline author-year formatter returned only the first token of the first author's last name (`surnames[0]`), so a multi-word surname like "Ben Allal" rendered as **"Ben et al."** Brace-protecting it in BibTeX (`{Ben Allal}`) made it worse — the braces printed literally — because surnames were never normalized.

Fix — a shared `_person_surname()` helper joins all last-name tokens and runs them through `_normalize_bibtex_field` (drops grouping braces, preserves LaTeX macros), used for the first author, the two-author "& second" case, and the references list.

`233 passed, 1 skipped.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)