### PR TITLE
Make slide text easy to copy: no nav on selection + 'c' copies slide markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ One line per PR for easy copy into GitHub releases.
 
 ## [Unreleased]
 
+- Don't advance slides when selecting/copying text — a click-drag or active text selection no longer triggers navigation ([#37](https://github.com/natolambert/colloquium/pull/37))
 - Fix `title: center` leaking center alignment to the whole slide body, and citation author surnames (keep full multi-word names, strip BibTeX braces) ([#36](https://github.com/natolambert/colloquium/pull/36))
 - Fix block animations for generated div-based elements ([#33](https://github.com/natolambert/colloquium/pull/33))
 - Bind dev server to loopback, change default port to 8090, and error on port conflicts ([#28](https://github.com/natolambert/colloquium/pull/28))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ One line per PR for easy copy into GitHub releases.
 
 ## [Unreleased]
 
-- Don't advance slides when selecting/copying text — a click-drag or active text selection no longer triggers navigation ([#37](https://github.com/natolambert/colloquium/pull/37))
+- Make slide text easier to get out: click-drag/selection no longer advances the slide, and press `c` to copy the current slide's markdown source to the clipboard ([#37](https://github.com/natolambert/colloquium/pull/37))
 - Fix `title: center` leaking center alignment to the whole slide body, and citation author surnames (keep full multi-word names, strip BibTeX braces) ([#36](https://github.com/natolambert/colloquium/pull/36))
 - Fix block animations for generated div-based elements ([#33](https://github.com/natolambert/colloquium/pull/33))
 - Bind dev server to loopback, change default port to 8090, and error on port conflicts ([#28](https://github.com/natolambert/colloquium/pull/28))

--- a/colloquium/build.py
+++ b/colloquium/build.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import html as html_module
 import re
 import tempfile
@@ -1253,7 +1254,12 @@ def _build_slide_html(
     inner = "\n".join(parts)
 
     fragment_attr = f' data-fragment-count="{fragment_count}"' if fragment_count > 0 else ""
-    return f'<section class="{class_str}"{slide_style_attr} data-index="{index}"{fragment_attr}>\n{inner}\n</section>'
+    # Embed the slide's markdown source (base64 of UTF-8) so the presentation
+    # engine can copy it to the clipboard. Base64 sidesteps all HTML-escaping
+    # and unicode pitfalls of carrying raw markdown in an attribute.
+    md_source = base64.b64encode(slide.to_markdown().encode("utf-8")).decode("ascii")
+    md_attr = f' data-colloquium-md="{md_source}"'
+    return f'<section class="{class_str}"{slide_style_attr} data-index="{index}"{fragment_attr}{md_attr}>\n{inner}\n</section>'
 
 
 # HTML template — uses $-style substitution

--- a/colloquium/themes/default/presentation.js
+++ b/colloquium/themes/default/presentation.js
@@ -399,6 +399,17 @@ class ColloquiumPresentation {
     }
 
     _bindClick() {
+        // Track the pointer-down position so we can tell a click from a drag.
+        // A drag (mouse moved between down and up) means the user was selecting
+        // text or otherwise interacting, not trying to advance the slide.
+        let downX = 0;
+        let downY = 0;
+        const DRAG_THRESHOLD = 8; // px of movement that counts as a drag, not a click
+        document.addEventListener('mousedown', (e) => {
+            downX = e.clientX;
+            downY = e.clientY;
+        });
+
         document.addEventListener('click', (e) => {
             // Handle citation links — navigate to the slide containing the target ref
             const citeLink = e.target.closest('a.colloquium-cite');
@@ -421,6 +432,14 @@ class ColloquiumPresentation {
 
             // Ignore clicks on links, interactive elements, footer, and picker
             if (e.target.closest('a, button, input, textarea, select, .colloquium-footer, .colloquium-picker-overlay, .colloquium-present, .colloquium-picker-trigger')) return;
+
+            // Don't navigate if the user is highlighting/copying text. A drag
+            // (pointer moved between down and up) or a live text selection both
+            // mean "select", not "next slide".
+            const dragDistance = Math.hypot(e.clientX - downX, e.clientY - downY);
+            if (dragDistance > DRAG_THRESHOLD) return;
+            const selection = window.getSelection();
+            if (selection && !selection.isCollapsed && selection.toString().trim()) return;
 
             const x = e.clientX / window.innerWidth;
             if (x < 0.33) {

--- a/colloquium/themes/default/presentation.js
+++ b/colloquium/themes/default/presentation.js
@@ -342,6 +342,14 @@ class ColloquiumPresentation {
                 e.preventDefault();
                 this.last();
                 break;
+            case 'c':
+            case 'C':
+                // Plain 'c' copies the current slide's markdown source.
+                // Leave Cmd/Ctrl+C alone so the browser can copy selected text.
+                if (e.metaKey || e.ctrlKey || e.altKey) return;
+                e.preventDefault();
+                this._copyCurrentSlideMarkdown();
+                break;
             case 'f':
             case 'F':
                 e.preventDefault();
@@ -438,6 +446,11 @@ class ColloquiumPresentation {
             // mean "select", not "next slide".
             const dragDistance = Math.hypot(e.clientX - downX, e.clientY - downY);
             if (dragDistance > DRAG_THRESHOLD) return;
+            // A multi-click (double/triple) is a word/paragraph selection gesture,
+            // not navigation. This catches the later clicks of a multi-click; the
+            // very first click can't be distinguished without deferring all
+            // navigation, which we avoid so slide clicks stay snappy.
+            if (e.detail > 1) return;
             const selection = window.getSelection();
             if (selection && !selection.isCollapsed && selection.toString().trim()) return;
 
@@ -489,6 +502,78 @@ class ColloquiumPresentation {
         } else {
             document.documentElement.requestFullscreen().catch(() => {});
         }
+    }
+
+    // --- Copy slide as markdown ---
+
+    _decodeMarkdown(b64) {
+        // base64 (UTF-8) → string, so unicode math/symbols round-trip cleanly.
+        const binary = atob(b64);
+        const bytes = Uint8Array.from(binary, c => c.charCodeAt(0));
+        return new TextDecoder().decode(bytes);
+    }
+
+    _copyCurrentSlideMarkdown() {
+        const slide = this.slides[this.currentIndex];
+        const encoded = slide && slide.getAttribute('data-colloquium-md');
+        if (!encoded) {
+            this._showToast('No markdown source for this slide');
+            return;
+        }
+        let markdown;
+        try {
+            markdown = this._decodeMarkdown(encoded);
+        } catch (_) {
+            this._showToast('Could not read slide markdown');
+            return;
+        }
+        const done = () => this._showToast('Copied slide markdown');
+        const fail = () => this._showToast('Copy failed — clipboard blocked');
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(markdown).then(done, () => {
+                if (!this._copyViaTextarea(markdown)) fail();
+                else done();
+            });
+        } else if (this._copyViaTextarea(markdown)) {
+            done();
+        } else {
+            fail();
+        }
+    }
+
+    _copyViaTextarea(text) {
+        // Fallback for insecure contexts (file://, plain http) where the async
+        // Clipboard API is unavailable.
+        const ta = document.createElement('textarea');
+        ta.value = text;
+        ta.setAttribute('readonly', '');
+        ta.style.position = 'fixed';
+        ta.style.top = '-1000px';
+        ta.style.opacity = '0';
+        document.body.appendChild(ta);
+        ta.select();
+        let ok = false;
+        try {
+            ok = document.execCommand('copy');
+        } catch (_) {
+            ok = false;
+        }
+        document.body.removeChild(ta);
+        return ok;
+    }
+
+    _showToast(message) {
+        if (!this._toast) {
+            this._toast = document.createElement('div');
+            this._toast.className = 'colloquium-toast';
+            document.body.appendChild(this._toast);
+        }
+        this._toast.textContent = message;
+        this._toast.classList.add('visible');
+        clearTimeout(this._toastTimer);
+        this._toastTimer = setTimeout(() => {
+            this._toast.classList.remove('visible');
+        }, 1500);
     }
 }
 

--- a/colloquium/themes/default/theme.css
+++ b/colloquium/themes/default/theme.css
@@ -1703,12 +1703,37 @@ body:hover .colloquium-present {
     }
 }
 
+/* ===== Toast (transient confirmation, e.g. "Copied slide markdown") ===== */
+.colloquium-toast {
+    position: fixed;
+    bottom: 24px;
+    left: 50%;
+    transform: translateX(-50%) translateY(8px);
+    z-index: 1000;
+    padding: 8px 16px;
+    border-radius: 6px;
+    background: rgba(20, 20, 20, 0.92);
+    color: #fff;
+    font-size: 14px;
+    font-family: var(--colloquium-font-body, sans-serif);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.colloquium-toast.visible {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+}
+
 /* ===== Capture mode — hide UI chrome for headless screenshots ===== */
 .colloquium-capture .colloquium-present,
 .colloquium-capture .colloquium-progress,
 .colloquium-capture .colloquium-overflow-warn,
 .colloquium-capture .colloquium-picker-trigger,
-.colloquium-capture .colloquium-picker-overlay {
+.colloquium-capture .colloquium-picker-overlay,
+.colloquium-capture .colloquium-toast {
     display: none !important;
 }
 


### PR DESCRIPTION
## What

Two related improvements for getting text/content out of slides:

1. **Selection no longer advances the slide.** A click-drag (highlight gesture) or a live text selection no longer triggers next/prev, so you can highlight and copy slide text normally.
2. **Press `c` to copy the current slide's markdown source** to the clipboard, with a small toast confirmation.

## How

**Selection guard** (`_bindClick`): record the pointer-down position on `mousedown`; on `click` skip navigation when the pointer moved >8px (a drag), when there's a live non-empty selection, or on a multi-click (`e.detail > 1`, i.e. double/triple-click word/paragraph select). A plain click still advances exactly as before.

**Copy as markdown:** at build time each slide's `to_markdown()` source is embedded in its `<section>` as `data-colloquium-md` (base64 of UTF-8 — sidesteps HTML-escaping and unicode pitfalls). Pressing plain `c` decodes it and writes to the clipboard via the async Clipboard API, with an `execCommand` textarea fallback for insecure contexts (`file://`). `Cmd/Ctrl+C` is deliberately left alone so selecting and copying text still works. The toast is hidden in capture mode.

## Note on double-click (review feedback)

The *first* click of a double-click can't be distinguished from a navigation click without deferring all single-click navigation ~250ms, which would make clicking through slides feel laggy. Since drag-to-select (the common copy gesture) is fully handled and `e.detail` blocks the later clicks of a multi-click, we accept that the very first click of a double-click may still advance rather than degrade the primary interaction.

## Testing

- `233 passed, 1 skipped`; `node -c` syntax check + example build pass
- Markdown round-trip verified (base64 decode of embedded attribute matches source)
- Manual: drag-highlight and `Cmd+C` copy text without nav; `c` copies slide markdown with toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)