### PR TITLE
Release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ One line per PR for easy copy into GitHub releases.
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-06-19
+
 - Make slide text easier to get out: click-drag/selection no longer advances the slide, and press `c` to copy the current slide's markdown source to the clipboard ([#37](https://github.com/natolambert/colloquium/pull/37))
 - Fix `title: center` leaking center alignment to the whole slide body, and citation author surnames (keep full multi-word names, strip BibTeX braces) ([#36](https://github.com/natolambert/colloquium/pull/36))
 - Fix block animations for generated div-based elements ([#33](https://github.com/natolambert/colloquium/pull/33))

--- a/colloquium/__init__.py
+++ b/colloquium/__init__.py
@@ -1,6 +1,6 @@
 """Colloquium — agent-native slide creation tool for research talks."""
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 from colloquium.slide import Slide
 from colloquium.deck import Deck

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "colloquium"
-version = "0.2.1"
+version = "0.2.2"
 description = "Agent-native slide creation tool for research talks"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "colloquium"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "markdown-it-py" },


### PR DESCRIPTION
Cuts **v0.2.2** (all changes accumulated under `[Unreleased]` since v0.2.1).

- Bump version to `0.2.2` in `pyproject.toml`, `colloquium/__init__.py`, and `uv.lock`
- Roll `[Unreleased]` changelog items into a dated `## [0.2.2] - 2026-06-19` section

## Changes in this release

- Make slide text easier to get out: click-drag/selection no longer advances the slide, and press `c` to copy the current slide's markdown source to the clipboard ([#37](https://github.com/natolambert/colloquium/pull/37))
- Fix `title: center` leaking center alignment to the whole slide body, and citation author surnames ([#36](https://github.com/natolambert/colloquium/pull/36))
- Fix block animations for generated div-based elements ([#33](https://github.com/natolambert/colloquium/pull/33))
- Bind dev server to loopback, change default port to 8090, and error on port conflicts ([#28](https://github.com/natolambert/colloquium/pull/28))
- Upgrade locked Pillow to 12.2.0 (CVE-2026-40192) ([#29](https://github.com/natolambert/colloquium/pull/29))
- Upgrade locked pytest to 9.0.3 and Pygments to 2.20.0 (CVE-2025-71176, CVE-2026-4539) ([#30](https://github.com/natolambert/colloquium/pull/30))
- Upgrade locked lxml to 6.1.0 (CVE-2026-41066) ([#31](https://github.com/natolambert/colloquium/pull/31))
- Add a built-in iframe element for embedding external or local HTML content ([#32](https://github.com/natolambert/colloquium/pull/32))
- Add fragment-based animations: `<!-- animate: bullets|blocks -->` and `<!-- step -->` ([#25](https://github.com/natolambert/colloquium/pull/25))
- Hide the mobile slide picker trigger when decks are embedded in iframes ([#35](https://github.com/natolambert/colloquium/pull/35))
- Add `<!-- after: references -->` for post-reference appendix slides ([#34](https://github.com/natolambert/colloquium/pull/34))

After merge: tag `v0.2.2` on the merge commit, publish the GitHub release, and upload to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)