### PR TITLE
Update presentation keyboard navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ One line per PR for easy copy into GitHub releases.
 
 ## [Unreleased]
 
-- Update presentation navigation: left/right step through reveal states then slides, up/down jump whole slides skipping reveals, typed slide numbers jump directly to pages, and the hello deck documents the controls ([#39](https://github.com/natolambert/colloquium/pull/39))
+- Update presentation navigation: left/right step through reveal states then slides; up/down, typed slide numbers, and the picker jump straight to a slide with all reveals shown ([#39](https://github.com/natolambert/colloquium/pull/39))
 
 ## [0.2.2] - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ One line per PR for easy copy into GitHub releases.
 
 ## [Unreleased]
 
+- Update presentation navigation: left/right jump directly between slides, up/down still controls reveal steps, typed slide numbers jump to pages, and the hello deck documents the controls ([#38](https://github.com/natolambert/colloquium/pull/38))
+
 ## [0.2.2] - 2026-06-19
 
 - Make slide text easier to get out: click-drag/selection no longer advances the slide, and press `c` to copy the current slide's markdown source to the clipboard ([#37](https://github.com/natolambert/colloquium/pull/37))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ One line per PR for easy copy into GitHub releases.
 
 ## [Unreleased]
 
-- Update presentation navigation: left/right jump directly between slides, up/down still controls reveal steps, typed slide numbers jump to pages, and the hello deck documents the controls ([#38](https://github.com/natolambert/colloquium/pull/38))
+- Update presentation navigation: left/right step through reveal states then slides, up/down jump whole slides skipping reveals, typed slide numbers jump directly to pages, and the hello deck documents the controls ([#39](https://github.com/natolambert/colloquium/pull/39))
 
 ## [0.2.2] - 2026-06-19
 

--- a/README.md
+++ b/README.md
@@ -602,12 +602,15 @@ A **References** slide is automatically appended with only the cited works.
 
 | Key | Action |
 |-----|--------|
-| Right / Down / Space / PgDn | Next slide |
-| Left / Up / PgUp | Previous slide |
+| Right / Space / PgDn | Advance: next reveal step, then next slide |
+| Left / PgUp | Back: previous reveal step, then previous slide |
+| Down / Up | Next / previous slide, skipping reveal steps |
+| 1–9 | Type a slide number to jump to it (Enter commits early, Esc cancels) |
 | Home | First slide |
 | End | Last slide |
+| C | Copy current slide's markdown source |
 | F | Toggle fullscreen |
-| Escape | Close picker / exit fullscreen |
+| Escape | Cancel typed number / close picker / exit fullscreen |
 
 Click the slide counter to open the slide picker. Click left 1/3 of screen to go back, right 2/3 to go forward.
 

--- a/README.md
+++ b/README.md
@@ -604,8 +604,8 @@ A **References** slide is automatically appended with only the cited works.
 |-----|--------|
 | Right / Space / PgDn | Advance: next reveal step, then next slide |
 | Left / PgUp | Back: previous reveal step, then previous slide |
-| Down / Up | Next / previous slide, skipping reveal steps |
-| 1–9 | Type a slide number to jump to it (Enter commits early, Esc cancels) |
+| Down / Up | Jump to next / previous slide, fully revealed |
+| 1–9 | Type a slide number to jump to it, fully revealed (Enter commits early, Esc cancels) |
 | Home | First slide |
 | End | Last slide |
 | C | Copy current slide's markdown source |

--- a/README.md
+++ b/README.md
@@ -610,7 +610,7 @@ A **References** slide is automatically appended with only the cited works.
 | End | Last slide |
 | C | Copy current slide's markdown source |
 | F | Toggle fullscreen |
-| Escape | Cancel typed number / close picker / exit fullscreen |
+| Escape | Cancel typed number / close picker / exit fullscreen (while fullscreen, the browser always exits fullscreen on Esc — that part can't be deferred) |
 
 Click the slide counter to open the slide picker. Click left 1/3 of screen to go back, right 2/3 to go forward.
 

--- a/colloquium/themes/default/presentation.js
+++ b/colloquium/themes/default/presentation.js
@@ -187,8 +187,11 @@ class ColloquiumPresentation {
         }
     }
 
+    // Jump-style navigation lands with all fragments revealed: jumping means
+    // skimming or referencing finished content, not presenting the build-up.
+    // Only Right/Left (next/prev) step through fragments.
     nextSlide() {
-        this.goTo(this.currentIndex + 1);
+        this.goTo(this.currentIndex + 1, true);
     }
 
     prevSlide() {
@@ -272,7 +275,7 @@ class ColloquiumPresentation {
 
         if (slideNumber >= 1 && slideNumber <= this.totalSlides) {
             if (this.pickerOpen) this._closePicker();
-            this.goTo(slideNumber - 1);
+            this.goTo(slideNumber - 1, true);
         } else {
             this._showToast('No slide ' + slideNumber);
         }
@@ -327,7 +330,7 @@ class ColloquiumPresentation {
                 '<span class="colloquium-picker-title">' + this._getSlideTitle(slide, i) + '</span>';
             btn.addEventListener('click', (e) => {
                 e.stopPropagation();
-                this.goTo(i);
+                this.goTo(i, true);
                 this._closePicker();
             });
             this.pickerItems.push(btn);

--- a/colloquium/themes/default/presentation.js
+++ b/colloquium/themes/default/presentation.js
@@ -119,6 +119,12 @@ class ColloquiumPresentation {
     goTo(index, showAllFragments = false) {
         if (index < 0 || index >= this.totalSlides) return;
 
+        // Cancel any pending numeric jump. The numeric commit path clears the
+        // buffer before calling goTo, so this is a no-op there; every other
+        // navigation path (click, touch, hash, picker, arrows) cancels a stale
+        // digit that would otherwise fire later and snap the deck unexpectedly.
+        this._clearSlideNumberBuffer();
+
         this.slides[this.currentIndex].classList.remove('active');
         this.currentIndex = index;
         this.slides[this.currentIndex].classList.add('active');
@@ -157,6 +163,9 @@ class ColloquiumPresentation {
     }
 
     next() {
+        // Fragment steps bypass goTo, so cancel any pending numeric jump here
+        // too (click/swipe advancing a fragment must not let a stale digit fire).
+        this._clearSlideNumberBuffer();
         const fc = this.fragmentCounts[this.currentIndex];
         const fs = this.fragmentStates[this.currentIndex];
         if (fc > 0 && fs < fc) {
@@ -168,6 +177,7 @@ class ColloquiumPresentation {
     }
 
     prev() {
+        this._clearSlideNumberBuffer();
         const fs = this.fragmentStates[this.currentIndex];
         if (fs > 0) {
             this.fragmentStates[this.currentIndex] = fs - 1;
@@ -415,24 +425,28 @@ class ColloquiumPresentation {
         if (this._handleSlideNumberKey(e)) return;
 
         switch (e.key) {
+            // Left/Right (and Space/PageDown) step through fragments then
+            // slides — the familiar PowerPoint/Keynote "advance" axis.
             case 'ArrowRight':
-                e.preventDefault();
-                this.nextSlide();
-                break;
-            case 'ArrowDown':
             case ' ':
             case 'PageDown':
                 e.preventDefault();
                 this.next();
                 break;
             case 'ArrowLeft':
-                e.preventDefault();
-                this.prevSlide();
-                break;
-            case 'ArrowUp':
             case 'PageUp':
                 e.preventDefault();
                 this.prev();
+                break;
+            // Up/Down jump whole slides, skipping fragments — a fast axis for
+            // moving past fragment-heavy slides.
+            case 'ArrowDown':
+                e.preventDefault();
+                this.nextSlide();
+                break;
+            case 'ArrowUp':
+                e.preventDefault();
+                this.prevSlide();
                 break;
             case 'Home':
                 e.preventDefault();

--- a/colloquium/themes/default/presentation.js
+++ b/colloquium/themes/default/presentation.js
@@ -349,6 +349,10 @@ class ColloquiumPresentation {
     }
 
     _openPicker() {
+        // Opening the picker cancels a pending numeric jump — otherwise the
+        // stale timer fires mid-browse, closing the picker and jumping away.
+        this._clearSlideNumberBuffer();
+
         // Highlight current slide
         this.pickerItems.forEach((btn, i) => {
             btn.classList.toggle('current', i === this.currentIndex);
@@ -364,6 +368,10 @@ class ColloquiumPresentation {
     }
 
     _closePicker() {
+        // Dismissing the picker also cancels a pending numeric jump (the
+        // commit path clears its buffer before closing, so this is a no-op
+        // there).
+        this._clearSlideNumberBuffer();
         this.overlay.classList.remove('active');
         this.pickerOpen = false;
     }

--- a/colloquium/themes/default/presentation.js
+++ b/colloquium/themes/default/presentation.js
@@ -10,6 +10,9 @@ class ColloquiumPresentation {
         this.currentIndex = 0;
         this.totalSlides = this.slides.length;
         this._iframeKeyboardRelayDocuments = new WeakSet();
+        this.slideNumberBuffer = '';
+        this.slideNumberTimer = null;
+        this.slideNumberCommitDelay = 700;
 
         if (this._isEmbedded()) {
             document.body.classList.add('colloquium-embedded');
@@ -174,12 +177,101 @@ class ColloquiumPresentation {
         }
     }
 
+    nextSlide() {
+        this.goTo(this.currentIndex + 1);
+    }
+
+    prevSlide() {
+        this.goTo(this.currentIndex - 1, true);
+    }
+
     first() {
         this.goTo(0);
     }
 
     last() {
         this.goTo(this.totalSlides - 1, true);
+    }
+
+    // --- Numeric Slide Jump ---
+
+    _handleSlideNumberKey(e) {
+        if (e.metaKey || e.ctrlKey || e.altKey) return false;
+
+        if (/^\d$/.test(e.key)) {
+            e.preventDefault();
+            this._appendSlideNumberDigit(e.key);
+            return true;
+        }
+
+        if (!this.slideNumberBuffer) return false;
+
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            this._commitSlideNumberBuffer();
+            return true;
+        }
+
+        if (e.key === 'Backspace') {
+            e.preventDefault();
+            this._removeSlideNumberDigit();
+            return true;
+        }
+
+        if (e.key === 'Escape') {
+            e.preventDefault();
+            this._clearSlideNumberBuffer();
+            return true;
+        }
+
+        this._clearSlideNumberBuffer();
+        return false;
+    }
+
+    _appendSlideNumberDigit(digit) {
+        this.slideNumberBuffer += digit;
+        clearTimeout(this.slideNumberTimer);
+
+        const maxDigits = String(this.totalSlides).length;
+        if (this.slideNumberBuffer.length >= maxDigits) {
+            this._commitSlideNumberBuffer();
+            return;
+        }
+
+        this.slideNumberTimer = setTimeout(() => {
+            this._commitSlideNumberBuffer();
+        }, this.slideNumberCommitDelay);
+    }
+
+    _removeSlideNumberDigit() {
+        this.slideNumberBuffer = this.slideNumberBuffer.slice(0, -1);
+        clearTimeout(this.slideNumberTimer);
+
+        if (this.slideNumberBuffer) {
+            this.slideNumberTimer = setTimeout(() => {
+                this._commitSlideNumberBuffer();
+            }, this.slideNumberCommitDelay);
+        }
+    }
+
+    _commitSlideNumberBuffer() {
+        if (!this.slideNumberBuffer) return;
+
+        const slideNumber = parseInt(this.slideNumberBuffer, 10);
+        this._clearSlideNumberBuffer();
+
+        if (slideNumber >= 1 && slideNumber <= this.totalSlides) {
+            if (this.pickerOpen) this._closePicker();
+            this.goTo(slideNumber - 1);
+        } else {
+            this._showToast('No slide ' + slideNumber);
+        }
+    }
+
+    _clearSlideNumberBuffer() {
+        this.slideNumberBuffer = '';
+        clearTimeout(this.slideNumberTimer);
+        this.slideNumberTimer = null;
     }
 
     // --- Fragment Management ---
@@ -320,8 +412,13 @@ class ColloquiumPresentation {
     }
 
     _handleNavigationKey(e) {
+        if (this._handleSlideNumberKey(e)) return;
+
         switch (e.key) {
             case 'ArrowRight':
+                e.preventDefault();
+                this.nextSlide();
+                break;
             case 'ArrowDown':
             case ' ':
             case 'PageDown':
@@ -329,6 +426,9 @@ class ColloquiumPresentation {
                 this.next();
                 break;
             case 'ArrowLeft':
+                e.preventDefault();
+                this.prevSlide();
+                break;
             case 'ArrowUp':
             case 'PageUp':
                 e.preventDefault();

--- a/examples/hello/hello.md
+++ b/examples/hello/hello.md
@@ -46,6 +46,17 @@ Nathan Lambert
 
 ---
 
+## Navigation
+
+<!-- animate: bullets -->
+
+- `←` / `→` jump one slide back or forward
+- `↑` / `↓` step through reveal states on the current slide
+- Type a slide number to jump directly to that page
+- Multi-digit numbers are buffered: typing `19` goes to slide 19, not slide 1 and then slide 9
+
+---
+
 ## LaTeX Math Support
 
 The loss function for RLHF with a KL penalty:

--- a/examples/hello/hello.md
+++ b/examples/hello/hello.md
@@ -50,8 +50,8 @@ Nathan Lambert
 
 <!-- animate: bullets -->
 
-- `←` / `→` jump one slide back or forward
-- `↑` / `↓` step through reveal states on the current slide
+- `←` / `→` step through animations, then move between slides
+- `↑` / `↓` jump straight to the previous / next slide, skipping animations
 - Type a slide number to jump directly to that page
 - Multi-digit numbers are buffered: typing `19` goes to slide 19, not slide 1 and then slide 9
 

--- a/examples/hello/hello.md
+++ b/examples/hello/hello.md
@@ -51,8 +51,8 @@ Nathan Lambert
 <!-- animate: bullets -->
 
 - `←` / `→` step through animations, then move between slides
-- `↑` / `↓` jump straight to the previous / next slide, skipping animations
-- Type a slide number to jump directly to that page
+- `↑` / `↓` jump straight to the previous / next slide, fully revealed
+- Type a slide number to jump directly to that page, fully revealed
 - Multi-digit numbers are buffered: typing `19` goes to slide 19, not slide 1 and then slide 9
 
 ---

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1606,6 +1606,54 @@ class TestFragments:
         assert "fragmentStates" in html
         assert "_updateFragments" in html
 
+    def test_left_right_arrows_jump_slides_while_up_down_steps_fragments(self):
+        deck = Deck(title="Test")
+        deck.add_slide(title="S1", content="A\n\n<!-- step -->\n\nB")
+        deck.add_slide(title="S2", content="C")
+        html = build_deck(deck)
+
+        import re
+
+        assert "nextSlide() {" in html
+        assert "prevSlide() {" in html
+        assert "this.goTo(this.currentIndex + 1);" in html
+        assert "this.goTo(this.currentIndex - 1, true);" in html
+        assert re.search(
+            r"case 'ArrowRight':\s+e\.preventDefault\(\);\s+this\.nextSlide\(\);",
+            html,
+        )
+        assert re.search(
+            r"case 'ArrowLeft':\s+e\.preventDefault\(\);\s+this\.prevSlide\(\);",
+            html,
+        )
+        assert re.search(
+            r"case 'ArrowDown':\s+case ' ':\s+case 'PageDown':\s+"
+            r"e\.preventDefault\(\);\s+this\.next\(\);",
+            html,
+        )
+        assert re.search(
+            r"case 'ArrowUp':\s+case 'PageUp':\s+"
+            r"e\.preventDefault\(\);\s+this\.prev\(\);",
+            html,
+        )
+
+    def test_number_keys_buffer_direct_slide_jump(self):
+        deck = Deck(title="Test")
+        for i in range(20):
+            deck.add_slide(title=f"S{i + 1}", content="Body")
+        html = build_deck(deck)
+
+        assert "this.slideNumberBuffer = '';" in html
+        assert "this.slideNumberCommitDelay = 700;" in html
+        assert "if (this._handleSlideNumberKey(e)) return;" in html
+        assert "if (/^\\d$/.test(e.key)) {" in html
+        assert "this._appendSlideNumberDigit(e.key);" in html
+        assert "if (e.key === 'Enter') {" in html
+        assert "this._commitSlideNumberBuffer();" in html
+        assert "this.slideNumberBuffer += digit;" in html
+        assert "this.slideNumberBuffer.length >= maxDigits" in html
+        assert "this.goTo(slideNumber - 1);" in html
+
     def test_li_with_arbitrary_attributes_gets_fragment_index(self):
         """Bullets with any attribute order must still get data-fragment-index."""
         from colloquium.build import _apply_auto_animate, _number_fragments

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1614,10 +1614,15 @@ class TestFragments:
 
         import re
 
-        assert "nextSlide() {" in html
-        assert "prevSlide() {" in html
-        assert "this.goTo(this.currentIndex + 1);" in html
-        assert "this.goTo(this.currentIndex - 1, true);" in html
+        # Jump-style navigation lands fully revealed (showAllFragments=true).
+        assert re.search(
+            r"nextSlide\(\) \{\s+this\.goTo\(this\.currentIndex \+ 1, true\);",
+            html,
+        )
+        assert re.search(
+            r"prevSlide\(\) \{\s+this\.goTo\(this\.currentIndex - 1, true\);",
+            html,
+        )
         # Left/Right (and Space/PageDown) advance through fragments then slides.
         assert re.search(
             r"case 'ArrowRight':\s+case ' ':\s+case 'PageDown':\s+"
@@ -1654,7 +1659,8 @@ class TestFragments:
         assert "this._commitSlideNumberBuffer();" in html
         assert "this.slideNumberBuffer += digit;" in html
         assert "this.slideNumberBuffer.length >= maxDigits" in html
-        assert "this.goTo(slideNumber - 1);" in html
+        # Numeric jumps land fully revealed, like all jump-style navigation.
+        assert "this.goTo(slideNumber - 1, true);" in html
         # goTo cancels any pending numeric jump so a stale digit can't fire
         # after the user navigates by click/touch/hash/picker; next()/prev()
         # cancel too, since fragment steps bypass goTo.

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1606,7 +1606,7 @@ class TestFragments:
         assert "fragmentStates" in html
         assert "_updateFragments" in html
 
-    def test_left_right_arrows_jump_slides_while_up_down_steps_fragments(self):
+    def test_left_right_step_fragments_while_up_down_jumps_slides(self):
         deck = Deck(title="Test")
         deck.add_slide(title="S1", content="A\n\n<!-- step -->\n\nB")
         deck.add_slide(title="S2", content="C")
@@ -1618,22 +1618,24 @@ class TestFragments:
         assert "prevSlide() {" in html
         assert "this.goTo(this.currentIndex + 1);" in html
         assert "this.goTo(this.currentIndex - 1, true);" in html
+        # Left/Right (and Space/PageDown) advance through fragments then slides.
         assert re.search(
-            r"case 'ArrowRight':\s+e\.preventDefault\(\);\s+this\.nextSlide\(\);",
-            html,
-        )
-        assert re.search(
-            r"case 'ArrowLeft':\s+e\.preventDefault\(\);\s+this\.prevSlide\(\);",
-            html,
-        )
-        assert re.search(
-            r"case 'ArrowDown':\s+case ' ':\s+case 'PageDown':\s+"
+            r"case 'ArrowRight':\s+case ' ':\s+case 'PageDown':\s+"
             r"e\.preventDefault\(\);\s+this\.next\(\);",
             html,
         )
         assert re.search(
-            r"case 'ArrowUp':\s+case 'PageUp':\s+"
+            r"case 'ArrowLeft':\s+case 'PageUp':\s+"
             r"e\.preventDefault\(\);\s+this\.prev\(\);",
+            html,
+        )
+        # Up/Down jump whole slides, skipping fragments.
+        assert re.search(
+            r"case 'ArrowDown':\s+e\.preventDefault\(\);\s+this\.nextSlide\(\);",
+            html,
+        )
+        assert re.search(
+            r"case 'ArrowUp':\s+e\.preventDefault\(\);\s+this\.prevSlide\(\);",
             html,
         )
 
@@ -1653,6 +1655,11 @@ class TestFragments:
         assert "this.slideNumberBuffer += digit;" in html
         assert "this.slideNumberBuffer.length >= maxDigits" in html
         assert "this.goTo(slideNumber - 1);" in html
+        # goTo cancels any pending numeric jump so a stale digit can't fire
+        # after the user navigates by click/touch/hash/picker; next()/prev()
+        # cancel too, since fragment steps bypass goTo.
+        assert "Cancel any pending numeric jump" in html
+        assert "Fragment steps bypass goTo" in html
 
     def test_li_with_arbitrary_attributes_gets_fragment_index(self):
         """Bullets with any attribute order must still get data-fragment-index."""

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1666,6 +1666,10 @@ class TestFragments:
         # cancel too, since fragment steps bypass goTo.
         assert "Cancel any pending numeric jump" in html
         assert "Fragment steps bypass goTo" in html
+        # Opening or dismissing the picker cancels a pending digit too, so a
+        # stale timer can't close the picker mid-browse and jump away.
+        assert "Opening the picker cancels a pending numeric jump" in html
+        assert "Dismissing the picker also cancels a pending numeric jump" in html
 
     def test_li_with_arbitrary_attributes_gets_fragment_index(self):
         """Bullets with any attribute order must still get data-fragment-index."""


### PR DESCRIPTION
Hey @natolambert ,

Big fan of your content! Spent the last few days watching RLHF lectures, waiting for the next ones now. Can't wait for the book to be out later this month.

I took freedom to open this pull request, hope it's helpful!

Two main things were done:
- Allow to type the number of the presentation page you want to go to. This is nice for when you are doing a presenting and now you will ned to go to a previous slide and can just use the numbers to go back - particularly more relevant the more slides there are. Powerpoint allows you to do this too.

- The left and up arrow have the same behavior, and so does the right and down. I made it so the left/right arrow are used to jump between slides and the up/down for granular content. In some of your presentations I noticed you had to click a lot of times on the arrow to show something even though the slide wasn't that far off just because you had a lot of independent text on the slide.

I updated the Hello World deck to mention this navigation updates. 

<img width="2846" height="962" alt="CleanShot 2026-07-05 at 16 37 54@2x" src="https://github.com/user-attachments/assets/7fe3bc37-d269-4bde-a164-9d76a1f70b89" />
