### PR TITLE
fix: load Google Fonts via <link> so custom fonts render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ One line per PR for easy copy into GitHub releases.
 ## [Unreleased]
 
 - Update presentation navigation: left/right step through reveal states then slides; up/down, typed slide numbers, and the picker jump straight to a slide with all reveals shown ([#39](https://github.com/natolambert/colloquium/pull/39))
+- Load Google Fonts with a `<link>` in `<head>` so custom `fonts:` from the frontmatter actually render instead of silently falling back to the theme default ([#41](https://github.com/natolambert/colloquium/pull/41))
 
 ## [0.2.2] - 2026-06-19
 

--- a/colloquium/build.py
+++ b/colloquium/build.py
@@ -1281,9 +1281,11 @@ _HTML_TEMPLATE = Template("""\
 <!-- highlight.js for code syntax highlighting -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.11.1/build/styles/github.min.css">
 <script defer src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.11.1/build/highlight.min.js"></script>
+$font_link
 
 <style>
 $theme_css
+$font_css
 $custom_css
 </style>
 </head>
@@ -1495,26 +1497,34 @@ window.addEventListener("load", function() {
 """)
 
 
-def _build_font_css(fonts: dict | None) -> str:
-    """Build CSS for custom font overrides, including Google Fonts @import."""
+def _build_font_link(fonts: dict | None) -> str:
+    """Build a <link> tag to load Google Fonts."""
     if not fonts:
         return ""
-    parts = []
     imports = []
+    for key in ("heading", "body"):
+        name = fonts.get(key)
+        if name:
+            imports.append(name.replace(" ", "+"))
+    if not imports:
+        return ""
+    families = "&family=".join(f"{f}:wght@400;600;700" for f in imports)
+    return f'<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family={families}&display=swap">'
+
+
+def _build_font_css(fonts: dict | None) -> str:
+    """Build CSS custom property overrides for font families."""
+    if not fonts:
+        return ""
     overrides = []
     for key, prop in (("heading", "--colloquium-font-heading"), ("body", "--colloquium-font-body")):
         name = fonts.get(key)
         if not name:
             continue
-        # Google Fonts URL: spaces become +
-        imports.append(name.replace(" ", "+"))
         overrides.append(f'    {prop}: "{name}", sans-serif;')
-    if imports:
-        families = "&family=".join(f"{f}:wght@400;600;700" for f in imports)
-        parts.append(f'@import url("https://fonts.googleapis.com/css2?family={families}&display=swap");')
-    if overrides:
-        parts.append(":root {\n" + "\n".join(overrides) + "\n}")
-    return "\n".join(parts)
+    if not overrides:
+        return ""
+    return ":root {\n" + "\n".join(overrides) + "\n}"
 
 
 def build_deck(deck: Deck) -> str:
@@ -1524,8 +1534,9 @@ def build_deck(deck: Deck) -> str:
     theme_css = _read_theme_css(deck.theme)
     presentation_js = _read_presentation_js(deck.theme)
 
+    font_link = _build_font_link(deck.fonts)
     font_css = _build_font_css(deck.fonts)
-    custom_css = font_css + ("\n" + deck.custom_css if deck.custom_css else "")
+    custom_css = deck.custom_css or ""
 
     # Load bibliography if configured
     bib_entries = {}
@@ -1627,6 +1638,8 @@ def build_deck(deck: Deck) -> str:
 
     return _HTML_TEMPLATE.substitute(
         title=deck.title,
+        font_link=font_link,
+        font_css=font_css,
         theme_css=theme_css,
         custom_css=custom_css,
         slides_html=slides_html,


### PR DESCRIPTION
Fixes #40 

Custom fonts declared through the `fonts:` frontmatter never load. The build emits the Google Fonts request as a CSS `@import` inside the `<style>` block, but it lands after the theme's CSS rules, and browsers ignore an `@import` that is not at the top of the stylesheet. So the font is never fetched and the `--colloquium-font-*` override silently falls back to the theme default (Inter). This affects the three decks in `examples/` (`hello`, `rows-and-columns`, `title-slides`) as well as user decks.

Filed as a companion issue with the full root-cause writeup and a self-contained repro against the shipped examples.

## The change

Load Google Fonts with a `<link rel="stylesheet">` in `<head>` instead of an in-stylesheet `@import`, and keep the `--colloquium-font-*` overrides after the theme CSS so they still win. A new `_build_font_link` helper builds the `<link>`, `_build_font_css` now returns only the `:root` override block, and the template gains `$font_link` in the head plus `$font_css` after `$theme_css`. This sidesteps the CSS ordering constraint entirely.

## Verification

Built the shipped examples and two of my own decks with this change. The generated HTML now carries a `<link>` to `fonts.googleapis.com` in the head, no stray `@import`, and the headings render in the requested families (Rubik, Space Grotesk, Playfair Display) instead of Inter. I have been running this patch locally first on `v0.2.1` and now on `v0.2.2`, and it has held up across both.
