### PR TITLE
Fix paragraph spacing swallowed by step fragment wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ One line per PR for easy copy into GitHub releases.
 
 ## [Unreleased]
 
+- Fix paragraph spacing swallowed by generated step/animate fragment wrappers (stepped paragraphs rendered flush with no line break) ([#43](https://github.com/natolambert/colloquium/pull/43))
 - Upgrade locked Pillow to 12.3.0 to fix 13 Dependabot alerts (heap OOB read/writes, decompression-bomb bypasses, DoS, command injection) ([#42](https://github.com/natolambert/colloquium/pull/42))
 - Update presentation navigation: left/right step through reveal states then slides; up/down, typed slide numbers, and the picker jump straight to a slide with all reveals shown ([#39](https://github.com/natolambert/colloquium/pull/39))
 - Load Google Fonts with a `<link>` in `<head>` so custom `fonts:` from the frontmatter actually render instead of silently falling back to the theme default ([#41](https://github.com/natolambert/colloquium/pull/41))

--- a/colloquium/themes/default/theme.css
+++ b/colloquium/themes/default/theme.css
@@ -110,6 +110,14 @@ html, body {
     margin-bottom: 0;
 }
 
+/* Step/animate reveals wrap blocks in generated fragment <div>s, which makes a
+   mid-slide paragraph :last-child of its wrapper and strips the 0.8em spacing
+   above -- visually merging it with the next fragment's paragraph. Restore the
+   margin unless the wrapper really is the last block in its container. */
+.slide div.fragment[data-fragment-index]:not(:last-child) > p:last-child {
+    margin-bottom: 0.8em;
+}
+
 .slide strong {
     font-weight: 600;
 }


### PR DESCRIPTION
## Summary

`<!-- step -->` between two paragraphs renders them visually merged — no paragraph break — even though the HTML structure is correct.

**Root cause:** step/animate reveals wrap each chunk in a generated `<div class="fragment">`. A mid-slide paragraph then becomes `:last-child` *of its wrapper*, so the theme rule `.slide p:last-child { margin-bottom: 0 }` (meant to trim trailing margins at the end of containers) strips its 0.8em spacing, and the next fragment's text sits flush against it.

**Fix:** one scoped CSS rule restoring the paragraph margin when the fragment wrapper is not the last block in its container:

```css
.slide div.fragment[data-fragment-index]:not(:last-child) > p:last-child {
    margin-bottom: 0.8em;
}
```

Scoped to `div.fragment` so `animate: bullets` `<li>` fragments are untouched; lists/pre/blockquote don't have a `:last-child` margin-zeroing rule, so paragraphs were the only affected block type.

## Verification

- Reproduced with a minimal two-column deck (`para / <!-- step --> / para`): before, the paragraphs render flush; after, `colloquium capture` shows the normal 0.8em gap.
- `pytest`: 235 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
