### PR TITLE
Apply smart typography inside box and conversation elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ One line per PR for easy copy into GitHub releases.
 
 ## [Unreleased]
 
+- Apply smart typography (en/em dashes, curly quotes) inside `box` and `conversation` elements by sharing the main pipeline's markdown-it config ([#44](https://github.com/natolambert/colloquium/pull/44))
 - Fix paragraph spacing swallowed by generated step/animate fragment wrappers (stepped paragraphs rendered flush with no line break) ([#43](https://github.com/natolambert/colloquium/pull/43))
 - Upgrade locked Pillow to 12.3.0 to fix 13 Dependabot alerts (heap OOB read/writes, decompression-bomb bypasses, DoS, command injection) ([#42](https://github.com/natolambert/colloquium/pull/42))
 - Update presentation navigation: left/right step through reveal states then slides; up/down, typed slide numbers, and the picker jump straight to a slide with all reveals shown ([#39](https://github.com/natolambert/colloquium/pull/39))

--- a/colloquium/build.py
+++ b/colloquium/build.py
@@ -12,6 +12,8 @@ from string import Template
 from markdown_it import MarkdownIt
 from mdit_py_plugins.dollarmath import dollarmath_plugin
 
+from colloquium.md import create_base_md
+
 from colloquium import elements
 from colloquium.deck import Deck
 from colloquium.slide import Slide
@@ -42,8 +44,7 @@ def _create_md_renderer() -> MarkdownIt:
     processing (e.g. _ becoming <em>). KaTeX renders the resulting
     .math elements client-side.
     """
-    md = MarkdownIt("commonmark", {"html": True, "typographer": True})
-    md.enable(["table", "replacements", "smartquotes"])
+    md = create_base_md()
     dollarmath_plugin(md, double_inline=True)
     return md
 

--- a/colloquium/elements/box.py
+++ b/colloquium/elements/box.py
@@ -4,14 +4,15 @@ import html as html_module
 import re
 
 import yaml
-from markdown_it import MarkdownIt
+
+from colloquium.md import create_base_md
 
 PATTERN = re.compile(
     r'<pre><code class="language-box">(.*?)</code></pre>',
     re.DOTALL,
 )
 
-_block_md = MarkdownIt("commonmark", {"html": True})
+_block_md = create_base_md()
 _SIMPLE_SCALAR_RE = re.compile(r"^(title|tone|align|size|compact):\s*(.+?)\s*$")
 
 

--- a/colloquium/elements/conversation.py
+++ b/colloquium/elements/conversation.py
@@ -4,7 +4,8 @@ import html as html_module
 import re
 
 import yaml
-from markdown_it import MarkdownIt
+
+from colloquium.md import create_base_md
 
 PATTERN = re.compile(
     r'<pre><code class="language-conversation">(.*?)</code></pre>',
@@ -12,7 +13,7 @@ PATTERN = re.compile(
 )
 
 _conversation_counter = 0
-_inline_md = MarkdownIt("commonmark", {"html": True})
+_inline_md = create_base_md()
 
 
 def reset() -> None:

--- a/colloquium/md.py
+++ b/colloquium/md.py
@@ -1,0 +1,15 @@
+"""Shared markdown-it configuration.
+
+Every renderer in colloquium (main slide pipeline and block elements like box
+and conversation) should build on this base so typography is consistent:
+smart quotes, en/em dashes from ``--``/``---``, and table support everywhere.
+"""
+
+from markdown_it import MarkdownIt
+
+
+def create_base_md() -> MarkdownIt:
+    """Return a markdown-it renderer with the deck's shared typography."""
+    md = MarkdownIt("commonmark", {"html": True, "typographer": True})
+    md.enable(["table", "replacements", "smartquotes"])
+    return md

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -238,6 +238,39 @@ class TestBuildDeck:
         assert "colloquium-box-title" in html
         assert "<li>One</li>" in html
 
+    def test_box_element_applies_smart_typography(self):
+        deck = Deck(title="Test")
+        deck.add_slide(
+            title="Box",
+            content=(
+                "```box\n"
+                "title: The plan\n"
+                "content: |\n"
+                "  **Basics** -- why models need \"tools\"\n"
+                "```"
+            ),
+        )
+        html = build_deck(deck)
+
+        assert "\u2013 why models need \u201ctools\u201d" in html
+
+    def test_conversation_element_applies_smart_typography(self):
+        deck = Deck(title="Test")
+        deck.add_slide(
+            title="Chat",
+            content=(
+                "```conversation\n"
+                "messages:\n"
+                "  - role: user\n"
+                "    content: |\n"
+                "      A question -- with a \"quote\"\n"
+                "```"
+            ),
+        )
+        html = build_deck(deck)
+
+        assert "\u2013 with a \u201cquote\u201d" in html
+
     def test_box_element_allows_unquoted_colon_in_title(self):
         deck = Deck(title="Test")
         deck.add_slide(


### PR DESCRIPTION
## Summary

Text inside ```box and ```conversation blocks didn't get smart typography: `--` rendered as two literal hyphens and quotes stayed straight, while the surrounding slide text got proper en dashes and curly quotes (screenshot case: "The plan" box on rlhfbook.com lecture decks).

**Root cause:** the two elements construct their own bare `MarkdownIt("commonmark", {"html": True})` instances, missing the `typographer: true` option and the `replacements`/`smartquotes` rules the main pipeline enables in `_create_md_renderer`.

**Fix:** factor the shared base config into `colloquium/md.py` (`create_base_md()`) and use it in the main pipeline, `box.py`, and `conversation.py` — so the three renderers can't drift again. The main pipeline still layers `dollarmath` on top; elements also gain `table` support, matching main-pipeline behavior.

## Tests

Two new tests assert `--` → – and `"..."` → curly quotes inside box content and conversation messages. Full suite: 237 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
