### PR TITLE
Raise PDF export virtual-time budget so late images render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ One line per PR for easy copy into GitHub releases.
 
 ## [Unreleased]
 
+- Raise the PDF export virtual-time budget (5s → 30s, overridable via `COLLOQUIUM_PDF_TIME_BUDGET_MS`) so the last images in image-heavy decks stop rendering blank in exported PDFs ([#45](https://github.com/natolambert/colloquium/pull/45))
 - Apply smart typography (en/em dashes, curly quotes) inside `box` and `conversation` elements by sharing the main pipeline's markdown-it config ([#44](https://github.com/natolambert/colloquium/pull/44))
 - Fix paragraph spacing swallowed by generated step/animate fragment wrappers (stepped paragraphs rendered flush with no line break) ([#43](https://github.com/natolambert/colloquium/pull/43))
 - Upgrade locked Pillow to 12.3.0 to fix 13 Dependabot alerts (heap OOB read/writes, decompression-bomb bypasses, DoS, command injection) ([#42](https://github.com/natolambert/colloquium/pull/42))

--- a/colloquium/export.py
+++ b/colloquium/export.py
@@ -14,6 +14,21 @@ from functools import partial
 from pathlib import Path
 from urllib.parse import quote
 
+# Chromium's print-to-pdf advances a virtual clock and snapshots the page when
+# the budget runs out — whether or not every slide image has finished loading.
+# 5s silently dropped the last images on image-heavy decks (blank in the PDF,
+# fine in the HTML preview), so the default is generous. Virtual time
+# fast-forwards through idle waits, so light decks don't pay for the headroom.
+_DEFAULT_PDF_TIME_BUDGET_MS = 30000
+
+
+def _pdf_time_budget_ms() -> int:
+    """PDF print budget in ms, overridable via COLLOQUIUM_PDF_TIME_BUDGET_MS."""
+    try:
+        return int(os.environ["COLLOQUIUM_PDF_TIME_BUDGET_MS"])
+    except (KeyError, ValueError):
+        return _DEFAULT_PDF_TIME_BUDGET_MS
+
 
 def _find_browser() -> str | None:
     """Find a headless-capable browser on the system."""
@@ -98,12 +113,14 @@ def _export_pdf_from_html(html_path: str, output_path: str) -> str | None:
             "--no-margins",
             f"--paper-width=10",
             f"--paper-height=5.625",
-            "--virtual-time-budget=5000",
+            f"--virtual-time-budget={_pdf_time_budget_ms()}",
             html_url,
         ]
 
         try:
-            subprocess.run(cmd, capture_output=True, timeout=30, check=True)
+            # Wall-clock timeout must comfortably exceed the virtual-time
+            # budget: pages that genuinely need the budget spend real time too.
+            subprocess.run(cmd, capture_output=True, timeout=120, check=True)
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
             return None
 

--- a/tests/test_pdf_export.py
+++ b/tests/test_pdf_export.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from urllib.request import urlopen
 
 from colloquium.export import _serve_html_for_export
@@ -14,3 +15,47 @@ def test_serve_html_for_export_serves_deck_over_loopback(tmp_path):
             body = response.read().decode("utf-8")
 
     assert "<title>Deck</title>" in body
+
+
+def _run_fake_export(monkeypatch, tmp_path):
+    """Drive _export_pdf_from_html with a stubbed browser; return the cmd."""
+    from colloquium import export as export_mod
+
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        # Simulate Chromium writing the PDF so the happy path completes.
+        for arg in cmd:
+            if arg.startswith("--print-to-pdf="):
+                Path(arg.split("=", 1)[1]).write_bytes(b"%PDF-1.4")
+
+    monkeypatch.setattr(export_mod, "_find_browser", lambda: "/fake/chrome")
+    monkeypatch.setattr(export_mod, "_compress_pdf", lambda path: None)
+    monkeypatch.setattr(export_mod.subprocess, "run", fake_run)
+
+    html_path = tmp_path / "deck.html"
+    html_path.write_text("<!doctype html><title>Deck</title>", encoding="utf-8")
+    output_path = str(tmp_path / "deck.pdf")
+
+    result = export_mod._export_pdf_from_html(str(html_path), output_path)
+    assert result == output_path
+    return captured["cmd"]
+
+
+def test_pdf_export_uses_generous_default_time_budget(monkeypatch, tmp_path):
+    monkeypatch.delenv("COLLOQUIUM_PDF_TIME_BUDGET_MS", raising=False)
+    cmd = _run_fake_export(monkeypatch, tmp_path)
+    assert "--virtual-time-budget=30000" in cmd
+
+
+def test_pdf_export_time_budget_env_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("COLLOQUIUM_PDF_TIME_BUDGET_MS", "7000")
+    cmd = _run_fake_export(monkeypatch, tmp_path)
+    assert "--virtual-time-budget=7000" in cmd
+
+
+def test_pdf_export_time_budget_ignores_bad_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("COLLOQUIUM_PDF_TIME_BUDGET_MS", "not-a-number")
+    cmd = _run_fake_export(monkeypatch, tmp_path)
+    assert "--virtual-time-budget=30000" in cmd


### PR DESCRIPTION
## Summary

`colloquium export` runs Chromium print-to-pdf with `--virtual-time-budget=5000`. On image-heavy decks the budget expires before the last images in document order finish loading, so they render blank in the PDF while the HTML preview is fine — hit in practice on rlhf-book's 41-slide lecture 11 deck, where the two final figures were silently dropped (and the same path builds the deployed `slides.pdf` for every course lecture).

## Changes

- Default the virtual-time budget to 30000ms via `_DEFAULT_PDF_TIME_BUDGET_MS`. Virtual time fast-forwards through idle waits, so decks that loaded fine at 5s don't get slower.
- Allow overriding with `COLLOQUIUM_PDF_TIME_BUDGET_MS` (bad values fall back to the default).
- Raise the wall-clock `subprocess.run` timeout 30s → 120s so real load time can use the budget.
- Tests: stubbed-browser tests asserting the default flag, env override, and bad-env fallback.

Verified end-to-end: full test suite passes (241 passed); exporting the lecture 11 deck with this branch renders the previously-dropped figures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)