### PR TITLE
Cap printed row images at their row's height share

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ One line per PR for easy copy into GitHub releases.
 
 ## [Unreleased]
 
+- Cap printed row images at their row's height share (emitted as `--colloquium-print-row-frac`) so tall figures in `rows` slides stop overflowing the page and silently shifting onto the next PDF page during export ([#46](https://github.com/natolambert/colloquium/pull/46))
 - Raise the PDF export virtual-time budget (5s → 30s, overridable via `COLLOQUIUM_PDF_TIME_BUDGET_MS`) so the last images in image-heavy decks stop rendering blank in exported PDFs ([#45](https://github.com/natolambert/colloquium/pull/45))
 - Apply smart typography (en/em dashes, curly quotes) inside `box` and `conversation` elements by sharing the main pipeline's markdown-it config ([#44](https://github.com/natolambert/colloquium/pull/44))
 - Fix paragraph spacing swallowed by generated step/animate fragment wrappers (stepped paragraphs rendered flush with no line break) ([#43](https://github.com/natolambert/colloquium/pull/43))

--- a/colloquium/build.py
+++ b/colloquium/build.py
@@ -1095,22 +1095,48 @@ def _write_text_atomic(output_path: str, text: str) -> None:
     tmp_path.replace(output)
 
 
+def _row_print_fractions(rows_spec: str | None, row_count: int) -> list[float]:
+    """Height fraction of each row, for the print-time image size cap.
+
+    Printed slides never run the runtime figure fit pass, so the theme's print
+    CSS caps row images at (usable slide height x row fraction) via the
+    --colloquium-print-row-frac variable emitted here. Without the cap, a row
+    image taller than its row overflows the fixed-height slide and Chromium's
+    print fragmentation moves it to the next PDF page.
+    """
+    if row_count <= 0:
+        return []
+    if rows_spec:
+        parts = [p for p in rows_spec.split("-") if p]
+        if rows_spec.isdigit():
+            parts = ["1"] * int(rows_spec)
+        if (
+            len(parts) == row_count
+            and all(p.isdigit() for p in parts)
+            and any(int(p) > 0 for p in parts)
+        ):
+            total = sum(int(p) for p in parts)
+            return [int(p) / total for p in parts]
+    return [1 / row_count] * row_count
+
+
 def _build_rows_html(
     content: str, md: MarkdownIt, figure_captions: bool = False,
-    animate_type: str | None = None,
+    animate_type: str | None = None, rows_spec: str | None = None,
 ) -> str:
     """Build a row-based slide body with optional nested columns in each row."""
     frag_animate = animate_type if animate_type in ("bullets", "items") else None
     row_blocks = [block.strip() for block in _ROW_SPLIT_RE.split(content) if block.strip()]
+    row_fractions = _row_print_fractions(rows_spec, len(row_blocks))
     rows_html = []
-    for block in row_blocks:
+    for row_index, block in enumerate(row_blocks):
         row_classes = ["colloquium-row"]
-        row_style = ""
+        row_style = f"--colloquium-print-row-frac: {row_fractions[row_index]:.4f};"
         for match in _ROW_COLUMNS_RE.finditer(block):
             spec = match.group(1).strip()
             row_classes.append(f'cols-{spec.replace("/", "-")}')
             row_classes.append("colloquium-grid")
-            row_style = _grid_template_style(spec.replace("/", "-"), "columns")
+            row_style += " " + _grid_template_style(spec.replace("/", "-"), "columns")
             block = block.replace(match.group(0), "")
 
         rendered = _render_markdown(block.strip(), md)
@@ -1185,12 +1211,12 @@ def _build_slide_html(
     if slide_content:
         figure_captions = _slide_uses_figure_captions(slide.classes, deck_figure_captions)
         if has_rows:
+            rows_spec = _extract_grid_spec(slide.classes, "rows-")
             rendered = _build_rows_html(
                 slide_content, md, figure_captions=figure_captions,
-                animate_type=animate_type,
+                animate_type=animate_type, rows_spec=rows_spec,
             )
             rendered, fragment_count = _number_fragments(rendered)
-            rows_spec = _extract_grid_spec(slide.classes, "rows-")
             rows_style = _grid_template_style(rows_spec or "", "rows")
             content_style_attr = f' style="{rows_style}"' if rows_style else ""
             parts.append(f'<div class="slide-content colloquium-rows"{content_style_attr}>{rendered}</div>')

--- a/colloquium/themes/default/theme.css
+++ b/colloquium/themes/default/theme.css
@@ -1592,15 +1592,16 @@ body:hover .colloquium-present {
 
     /* Hidden slides never get the runtime figure fit pass, so printed grid
        figures need an explicit container-sized fallback. (Row figures are
-       excluded: they get the row-fraction cap below instead.) */
-    .slide .slide-content > figure.colloquium-figure:first-child:last-child,
-    .slide .slide-content.colloquium-grid > .col > figure.colloquium-figure:first-child:last-child {
+       excluded: they get the row-fraction cap below instead. img-overflow
+       slides opted into a deliberate bleed, so no print cap applies.) */
+    .slide:not(.img-overflow) .slide-content > figure.colloquium-figure:first-child:last-child,
+    .slide:not(.img-overflow) .slide-content.colloquium-grid > .col > figure.colloquium-figure:first-child:last-child {
         width: 100% !important;
         max-width: 100% !important;
     }
 
-    .slide .slide-content > figure.colloquium-figure:first-child:last-child > img,
-    .slide .slide-content.colloquium-grid > .col > figure.colloquium-figure:first-child:last-child > img {
+    .slide:not(.img-overflow) .slide-content > figure.colloquium-figure:first-child:last-child > img,
+    .slide:not(.img-overflow) .slide-content.colloquium-grid > .col > figure.colloquium-figure:first-child:last-child > img {
         width: 100% !important;
         height: auto !important;
         max-width: 100% !important;
@@ -1613,7 +1614,7 @@ body:hover .colloquium-present {
        print fragmentation then silently moves the whole image onto the next
        PDF page. --colloquium-print-row-frac is emitted on each row at build
        time; 96px approximates the title block. */
-    .slide .colloquium-row img {
+    .slide:not(.img-overflow) .colloquium-row img {
         width: auto !important;
         height: auto !important;
         max-width: 100% !important;
@@ -1624,7 +1625,7 @@ body:hover .colloquium-present {
     }
 
     /* Leave room for the caption under captioned row figures. */
-    .slide .colloquium-row figure.colloquium-figure:has(> figcaption) > img {
+    .slide:not(.img-overflow) .colloquium-row figure.colloquium-figure:has(> figcaption) > img {
         max-height: calc(
             (720px - var(--colloquium-slide-padding) * 2 - 96px)
             * var(--colloquium-print-row-frac, 1) - 48px

--- a/colloquium/themes/default/theme.css
+++ b/colloquium/themes/default/theme.css
@@ -1590,22 +1590,45 @@ body:hover .colloquium-present {
         overflow: visible !important;
     }
 
-    /* Hidden slides never get the runtime figure fit pass, so printed grid/row
-       figures need an explicit container-sized fallback. */
+    /* Hidden slides never get the runtime figure fit pass, so printed grid
+       figures need an explicit container-sized fallback. (Row figures are
+       excluded: they get the row-fraction cap below instead.) */
     .slide .slide-content > figure.colloquium-figure:first-child:last-child,
-    .slide .colloquium-grid > .col > figure.colloquium-figure:first-child:last-child,
-    .slide .colloquium-row > figure.colloquium-figure:first-child:last-child {
+    .slide .slide-content.colloquium-grid > .col > figure.colloquium-figure:first-child:last-child {
         width: 100% !important;
         max-width: 100% !important;
     }
 
     .slide .slide-content > figure.colloquium-figure:first-child:last-child > img,
-    .slide .colloquium-grid > .col > figure.colloquium-figure:first-child:last-child > img,
-    .slide .colloquium-row > figure.colloquium-figure:first-child:last-child > img {
+    .slide .slide-content.colloquium-grid > .col > figure.colloquium-figure:first-child:last-child > img {
         width: 100% !important;
         height: auto !important;
         max-width: 100% !important;
         max-height: calc(720px - var(--colloquium-slide-padding) * 2 - 100px) !important;
+    }
+
+    /* Row images: cap to the row's height share of the slide. On screen the
+       runtime fit pass sizes these, but printed slides never run it, and an
+       image taller than its row overflows the fixed-height slide -- Chromium's
+       print fragmentation then silently moves the whole image onto the next
+       PDF page. --colloquium-print-row-frac is emitted on each row at build
+       time; 96px approximates the title block. */
+    .slide .colloquium-row img {
+        width: auto !important;
+        height: auto !important;
+        max-width: 100% !important;
+        max-height: calc(
+            (720px - var(--colloquium-slide-padding) * 2 - 96px)
+            * var(--colloquium-print-row-frac, 1)
+        ) !important;
+    }
+
+    /* Leave room for the caption under captioned row figures. */
+    .slide .colloquium-row figure.colloquium-figure:has(> figcaption) > img {
+        max-height: calc(
+            (720px - var(--colloquium-slide-padding) * 2 - 96px)
+            * var(--colloquium-print-row-frac, 1) - 48px
+        ) !important;
     }
 
     /* Printed slides are not .active, so re-apply layout/utility rules without that gate. */

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,5 +1,6 @@
 """Tests for the HTML builder."""
 
+import re
 import tempfile
 from pathlib import Path
 
@@ -466,6 +467,59 @@ class TestBuildDeck:
         html = build_deck(deck)
 
         assert 'grid-template-rows: minmax(0, 25fr) minmax(0, 75fr);' in html
+
+    def test_rows_emit_print_row_fractions(self):
+        """Each row carries its height share for the print image-size cap."""
+        deck = Deck(title="Test")
+        deck.add_slide(
+            title="Rows",
+            content="Top\n\n===\n\nBottom",
+            classes=["rows-40-60"],
+        )
+        html = build_deck(deck)
+
+        assert 'style="--colloquium-print-row-frac: 0.4000;"' in html
+        assert 'style="--colloquium-print-row-frac: 0.6000;"' in html
+
+    def test_rows_count_spec_emits_equal_print_fractions(self):
+        deck = Deck(title="Test")
+        deck.add_slide(
+            title="Rows",
+            content="Top\n\n===\n\nBottom",
+            classes=["rows-2"],
+        )
+        html = build_deck(deck)
+
+        assert html.count('--colloquium-print-row-frac: 0.5000;') == 2
+
+    def test_rows_mismatched_spec_falls_back_to_equal_fractions(self):
+        """A spec that doesn't match the row count splits evenly instead."""
+        deck = Deck(title="Test")
+        deck.add_slide(
+            title="Rows",
+            content="One\n\n===\n\nTwo\n\n===\n\nThree",
+            classes=["rows-40-60"],
+        )
+        html = build_deck(deck)
+
+        assert html.count('--colloquium-print-row-frac: 0.3333;') == 3
+
+    def test_rows_nested_columns_keep_print_fraction_and_grid(self):
+        """The row-frac var must coexist with a nested column grid template."""
+        deck = Deck(title="Test")
+        deck.add_slide(
+            title="Rows",
+            content="<!-- row-columns: 40/60 -->\nLeft\n\n|||\n\nRight\n\n===\n\nBottom",
+            classes=["rows-35-65"],
+        )
+        html = build_deck(deck)
+
+        assert re.search(
+            r'class="colloquium-row cols-40-60 colloquium-grid" '
+            r'style="--colloquium-print-row-frac: 0\.3500; '
+            r'grid-template-columns: minmax\(0, 40fr\) minmax\(0, 60fr\);"',
+            html,
+        )
 
     def test_no_columns_preserves_hr(self):
         deck = Deck(title="Test")
@@ -1790,7 +1844,7 @@ class TestFragments:
         deck.slides.append(slide)
         html = build_deck(deck)
         assert 'data-fragment-count="4"' in html
-        assert '<div class="colloquium-row"><div class="fragment"' in html
+        assert re.search(r'<div class="colloquium-row" style="[^"]*"><div class="fragment"', html)
 
     def test_blocks_wraps_markdown_headings(self):
         """Blocks mode must treat markdown headings as top-level fragments."""
@@ -1918,11 +1972,12 @@ class TestFragments:
         deck.slides.append(slide)
         html = build_deck(deck)
         assert 'data-fragment-count="1"' in html
-        assert (
-            '<div class="colloquium-row"><p>Top</p>\n'
-            '<div class="fragment" data-fragment-index="1"><p>Top step</p></div>'
-            '</div><div class="colloquium-row"><p>Bottom</p>\n</div>'
-        ) in html
+        assert re.search(
+            r'<div class="colloquium-row" style="[^"]*"><p>Top</p>\n'
+            r'<div class="fragment" data-fragment-index="1"><p>Top step</p></div>'
+            r'</div><div class="colloquium-row" style="[^"]*"><p>Bottom</p>\n</div>',
+            html,
+        )
 
     def test_step_blockquote_with_nested_bullets(self):
         """Step group with a blockquote containing fragments must wrap the blockquote."""


### PR DESCRIPTION
## Summary

Fixes silently missing/shifted images in exported PDFs for `rows` slides. Diagnosed while building rlhf-book Lecture 13 (natolambert/rlhf-book#498): a 2.4:1 chart in the 60% row of a `rows: 40/60` slide rendered fine in the HTML preview but vanished from its page in the exported PDF — `pdfimages` showed the image object painted on the *next* page.

## Root cause

Printed slides never run the runtime figure fit pass, and the print-CSS fallback added for that only covers figures that are a slide's sole content (with a whole-slide `max-height` cap). A row image below a text row gets `width: 100% !important` from that fallback, renders taller than its row, overflows the fixed 720px slide, and Chromium's print fragmentation treats the image as atomic — moving it wholesale onto the next PDF page. No error, no blank box on the source page beyond missing content. Percentage- and flex-based containment can't fix it in the print path (percentages resolve against auto-height figure boxes; flexed figures hit fragmentation bugs and paint at zero size).

## Fix

- `build.py` emits each row's height share as `--colloquium-print-row-frac` (from the `rows-NN-NN` spec; equal split for count specs or a mismatched spec).
- The print stylesheet caps row images at `(720px − 2·padding − 96px) × fraction`, with extra room reserved under captioned figures, and scopes the old only-child fallback to non-row layouts so the rules don't fight.

## Verification

- Reconstructed the failing Lecture 13 configuration (full-res figures, captioned charts in 40/60 and 42/58 rows slides): before the patch the chart lands on the wrong PDF page; after, every image is on its own slide's page, sized to its row, captions clear of the footer.
- `examples/rows-and-columns` exports unchanged and clean (including the 65/35 big-image slide).
- 244 tests pass; new tests cover fraction emission (ratio spec, count spec, mismatched-spec fallback, coexistence with nested column grid templates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
