### PR TITLE
Return equal fractions directly for numeric row count specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ One line per PR for easy copy into GitHub releases.
 
 ## [Unreleased]
 
+- Fix a purely numeric `rows` count spec (e.g. a typo'd `rows: 100000000`) allocating a count-sized list and potentially exhausting memory during builds ([#47](https://github.com/natolambert/colloquium/pull/47))
 - Cap printed row images at their row's height share (emitted as `--colloquium-print-row-frac`) so tall figures in `rows` slides stop overflowing the page and silently shifting onto the next PDF page during export ([#46](https://github.com/natolambert/colloquium/pull/46))
 - Raise the PDF export virtual-time budget (5s → 30s, overridable via `COLLOQUIUM_PDF_TIME_BUDGET_MS`) so the last images in image-heavy decks stop rendering blank in exported PDFs ([#45](https://github.com/natolambert/colloquium/pull/45))
 - Apply smart typography (en/em dashes, curly quotes) inside `box` and `conversation` elements by sharing the main pipeline's markdown-it config ([#44](https://github.com/natolambert/colloquium/pull/44))

--- a/colloquium/build.py
+++ b/colloquium/build.py
@@ -1107,9 +1107,13 @@ def _row_print_fractions(rows_spec: str | None, row_count: int) -> list[float]:
     if row_count <= 0:
         return []
     if rows_spec:
-        parts = [p for p in rows_spec.split("-") if p]
+        # A pure count spec means equal rows whether or not it matches the
+        # actual row blocks, so return directly instead of materializing a
+        # count-sized list -- a spec like `rows: 100000000` would otherwise
+        # exhaust memory.
         if rows_spec.isdigit():
-            parts = ["1"] * int(rows_spec)
+            return [1 / row_count] * row_count
+        parts = [p for p in rows_spec.split("-") if p]
         if (
             len(parts) == row_count
             and all(p.isdigit() for p in parts)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -492,6 +492,18 @@ class TestBuildDeck:
 
         assert html.count('--colloquium-print-row-frac: 0.5000;') == 2
 
+    def test_rows_huge_count_spec_does_not_allocate(self):
+        """An absurd count spec must not materialize a count-sized list."""
+        deck = Deck(title="Test")
+        deck.add_slide(
+            title="Rows",
+            content="Top\n\n===\n\nBottom",
+            classes=["rows-100000000"],
+        )
+        html = build_deck(deck)
+
+        assert html.count('--colloquium-print-row-frac: 0.5000;') == 2
+
     def test_rows_mismatched_spec_falls_back_to_equal_fractions(self):
         """A spec that doesn't match the row count splits evenly instead."""
         deck = Deck(title="Test")


### PR DESCRIPTION
Addresses the P2 follow-up on #46 (https://github.com/natolambert/colloquium/pull/46#discussion_r3692499081).

`_row_print_fractions` expanded a purely numeric spec into a count-sized list (`["1"] * int(rows_spec)`) before checking it against the actual row count, so a typo'd or absurd spec like `rows: 100000000` could exhaust memory and kill the build.

Since a numeric count spec always resolves to equal fractions — whether it matches the row blocks or not — the digit branch now returns them directly without allocating anything. Behavior is unchanged for all valid specs; a regression test covers the huge-count case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)