### PR TITLE
Warn when a bibliography fails to parse instead of silently dropping all citations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ One line per PR for easy copy into GitHub releases.
 
 ## [Unreleased]
 
+- Warn on stderr when a bibliography fails to parse (or pybtex is missing) instead of silently rendering every citation unresolved ([#48](https://github.com/natolambert/colloquium/pull/48))
 - Fix a purely numeric `rows` count spec (e.g. a typo'd `rows: 100000000`) allocating a count-sized list and potentially exhausting memory during builds ([#47](https://github.com/natolambert/colloquium/pull/47))
 - Cap printed row images at their row's height share (emitted as `--colloquium-print-row-frac`) so tall figures in `rows` slides stop overflowing the page and silently shifting onto the next PDF page during export ([#46](https://github.com/natolambert/colloquium/pull/46))
 - Raise the PDF export virtual-time budget (5s → 30s, overridable via `COLLOQUIUM_PDF_TIME_BUDGET_MS`) so the last images in image-heavy decks stop rendering blank in exported PDFs ([#45](https://github.com/natolambert/colloquium/pull/45))

--- a/colloquium/build.py
+++ b/colloquium/build.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import html as html_module
 import re
+import sys
 import tempfile
 from pathlib import Path
 from string import Template
@@ -401,12 +402,30 @@ _CITATION_RE = re.compile(r'\[@([\w:.\-]+(?:\s*;\s*@[\w:.\-]+)*)\]')
 
 
 def _parse_bib_file(path: str) -> dict:
-    """Parse a .bib file using pybtex. Returns dict of key -> entry."""
+    """Parse a .bib file using pybtex. Returns dict of key -> entry.
+
+    Failures are non-fatal (the deck still builds) but must be loud: a
+    single malformed entry makes pybtex raise, and silently returning {}
+    leaves every citation in the deck unresolved with no hint why.
+    """
     try:
         from pybtex.database import parse_file as pybtex_parse
+    except ImportError:
+        print(
+            f"Warning: pybtex is not installed; skipping bibliography {path!r} "
+            "(citations will not resolve)",
+            file=sys.stderr,
+        )
+        return {}
+    try:
         bib = pybtex_parse(path, bib_format="bibtex")
         return dict(bib.entries)
-    except Exception:
+    except Exception as exc:
+        print(
+            f"Warning: failed to parse bibliography {path!r}: {exc} "
+            "-- citations will not resolve",
+            file=sys.stderr,
+        )
         return {}
 
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -927,6 +927,24 @@ class TestCitationRendering:
             assert "colloquium-cite" in result
             assert "smith2024" in cited_keys
 
+    def test_malformed_bib_warns_and_returns_empty(self, capsys):
+        """A broken entry must not silently disable every citation."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bib_path = Path(tmpdir) / "refs.bib"
+            bib_path.write_text(
+                "@article{broken2024,\n  title={Missing closing brace}\n"
+                "@article{next2024,\n  title={Next},\n  year={2024}\n}\n"
+            )
+            assert _parse_bib_file(str(bib_path)) == {}
+            err = capsys.readouterr().err
+            assert "Warning: failed to parse bibliography" in err
+            assert "refs.bib" in err
+            assert "citations will not resolve" in err
+
+    def test_missing_bib_file_warns_and_returns_empty(self, capsys):
+        assert _parse_bib_file("/nonexistent/refs.bib") == {}
+        assert "Warning: failed to parse bibliography" in capsys.readouterr().err
+
     def test_numeric_style(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             bib_path = self._make_bib(tmpdir)


### PR DESCRIPTION
## Summary

`_parse_bib_file` wraps pybtex in `except Exception: return {}` — so a single malformed entry (pybtex raises on the whole file) builds the deck cleanly with **every citation unresolved** and no hint why.

Hit in practice on rlhf-book: a merge-conflict resolution in `refs.bib` dropped one closing brace, and the lecture deck silently rendered raw `[@key]`s everywhere while looking otherwise fine.

## Changes

- Print the pybtex parse error to stderr (`Warning: failed to parse bibliography 'refs.bib': syntax error in line N ... -- citations will not resolve`)
- Separate message when pybtex itself is not installed
- Behavior stays non-fatal: still returns `{}` and the deck still builds
- Tests: malformed bib and missing file both warn and return empty; suite at 247 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)