### PR TITLE
Release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ One line per PR for easy copy into GitHub releases.
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-08-03
+
 - Warn on stderr when a bibliography fails to parse (or pybtex is missing) instead of silently rendering every citation unresolved ([#48](https://github.com/natolambert/colloquium/pull/48))
 - Fix a purely numeric `rows` count spec (e.g. a typo'd `rows: 100000000`) allocating a count-sized list and potentially exhausting memory during builds ([#47](https://github.com/natolambert/colloquium/pull/47))
 - Cap printed row images at their row's height share (emitted as `--colloquium-print-row-frac`) so tall figures in `rows` slides stop overflowing the page and silently shifting onto the next PDF page during export ([#46](https://github.com/natolambert/colloquium/pull/46))

--- a/colloquium/__init__.py
+++ b/colloquium/__init__.py
@@ -1,6 +1,6 @@
 """Colloquium — agent-native slide creation tool for research talks."""
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 from colloquium.slide import Slide
 from colloquium.deck import Deck

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "colloquium"
-version = "0.2.2"
+version = "0.2.3"
 description = "Agent-native slide creation tool for research talks"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "colloquium"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "markdown-it-py" },


### PR DESCRIPTION
Cut release v0.2.3: bump version in `pyproject.toml`, `colloquium/__init__.py`, and `uv.lock`, and move the Unreleased changelog entries under a `## [0.2.3]` heading.

Includes #39, #41–#48 (see CHANGELOG.md for the full list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)