### PR TITLE
Caption fit: reserve caption height, respect author positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ One line per PR for easy copy into GitHub releases.
 
 ## [Unreleased]
 
+- Fix captioned-figure fitting scaling images to the full cell height so the caption overflowed onto the footer: the fit pass now reserves the caption's height, and skips absolutely positioned figures so author CSS can own layout. Captioned solo figures render slightly smaller (image + caption now fit the cell together) ([#50](https://github.com/natolambert/colloquium/pull/50))
+- Add opt-in `img-tall-right` slide class: on a columns slide, the right column's captioned figure runs from the slide top to the content bottom with the caption pinned beneath ([#50](https://github.com/natolambert/colloquium/pull/50))
+
 ## [0.2.3] - 2026-08-03
 
 - Warn on stderr when a bibliography fails to parse (or pybtex is missing) instead of silently rendering every citation unresolved ([#48](https://github.com/natolambert/colloquium/pull/48))

--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ At the slide root, use either `columns:` or `rows:`. For nested layouts, use `ro
 | `<!-- class: no-figure-captions -->` | Disable deck-wide figure captions for a specific slide |
 | `<!-- img-align: center -->` | Align images only (`left`, `center`, `right`) — title unaffected |
 | `<!-- img-valign: top -->` | Vertically align standalone images in grid/row cells (`top`, `center`, `bottom`) |
+| `<!-- class: img-tall-right -->` | Columns slides: the right column's captioned figure runs full slide height, caption beneath |
 | `<!-- img-fill: true -->` | Expand image to fill available slide space |
 | `<!-- img-overflow: true -->` | Let images in grid cells bleed outside their box instead of fitting inside |
 

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ At the slide root, use either `columns:` or `rows:`. For nested layouts, use `ro
 | `<!-- class: no-figure-captions -->` | Disable deck-wide figure captions for a specific slide |
 | `<!-- img-align: center -->` | Align images only (`left`, `center`, `right`) — title unaffected |
 | `<!-- img-valign: top -->` | Vertically align standalone images in grid/row cells (`top`, `center`, `bottom`) |
-| `<!-- class: img-tall-right -->` | Columns slides: the right column's captioned figure runs full slide height, caption beneath |
+| `<!-- class: img-tall-right -->` | Columns slides: the right column's captioned figure runs full slide height, caption beneath. Requires figure captions (`figure_captions: true` or the `figure-captions` class) so the image renders as a `figure` |
 | `<!-- img-fill: true -->` | Expand image to fill available slide space |
 | `<!-- img-overflow: true -->` | Let images in grid cells bleed outside their box instead of fitting inside |
 

--- a/colloquium/build.py
+++ b/colloquium/build.py
@@ -1389,6 +1389,10 @@ window.colloquiumFitCaptionedFiguresIn = function(root) {
         var caption = figure.querySelector("figcaption");
         if (!img || !caption) return;
 
+        // Authors can take over layout entirely (e.g. absolutely positioned
+        // full-height figures); leave those untouched.
+        if (window.getComputedStyle(figure).position === "absolute") return;
+
         var container = figure.parentElement;
         if (!container) return;
 
@@ -1408,8 +1412,15 @@ window.colloquiumFitCaptionedFiguresIn = function(root) {
         }
 
         var availableWidth = container.clientWidth;
-        var availableHeight = container.clientHeight;
-        if (!availableWidth || !availableHeight) return;
+        // The caption sits below the image inside the figure: reserve its
+        // height (plus the figure's own gap) so the scaled image + caption
+        // fit the cell together instead of the caption overflowing onto
+        // whatever sits below (usually the footer).
+        var captionHeight = caption.offsetHeight || 0;
+        var figureStyle = window.getComputedStyle(figure);
+        var figureGap = parseFloat(figureStyle.rowGap || figureStyle.gap) || 0;
+        var availableHeight = container.clientHeight - captionHeight - figureGap;
+        if (!availableWidth || availableHeight <= 0) return;
 
         var scale = Math.min(
             availableWidth / naturalWidth,

--- a/colloquium/themes/default/theme.css
+++ b/colloquium/themes/default/theme.css
@@ -1732,6 +1732,20 @@ body:hover .colloquium-present {
     .size-normal { font-size: 24px; }
     .size-large { font-size: 28px; }
 
+    /* img-tall-right: keep the full-height figure layout in print; the
+       generic grid-figure fallback above would otherwise force height auto
+       and a capped max-height. */
+    .slide.img-tall-right .colloquium-grid > .col:last-child > figure.colloquium-figure:first-child:last-child {
+        width: 55% !important;
+        max-width: 55% !important;
+    }
+    .slide.img-tall-right .colloquium-grid > .col:last-child > figure.colloquium-figure:first-child:last-child > img {
+        width: 100% !important;
+        height: calc(100% - 1.5em) !important;
+        max-width: none !important;
+        max-height: none !important;
+    }
+
     .colloquium-progress,
     .colloquium-picker-overlay,
     .colloquium-present,

--- a/colloquium/themes/default/theme.css
+++ b/colloquium/themes/default/theme.css
@@ -716,6 +716,43 @@ html, body {
 }
 
 /* ===== Utility: Vertical Alignment ===== */
+/* ===== Utility: Tall right figure =====
+   Opt-in slide class (<!-- class: img-tall-right -->) for columns slides:
+   the right column's captioned figure escapes the grid and runs from the
+   top of the slide to the bottom of the content area, caption pinned
+   beneath. The caption-fit pass skips absolutely positioned figures, so
+   these rules own the layout. */
+.slide.img-tall-right { position: relative; }
+.slide.img-tall-right .colloquium-grid > .col:last-child > figure.colloquium-figure:first-child:last-child {
+    position: absolute;
+    top: 10px;
+    bottom: 42px;
+    right: 30px;
+    width: 55%;
+    height: auto;
+    max-height: none;
+    margin: 0;
+    display: block;
+}
+.slide.img-tall-right .colloquium-grid > .col:last-child > figure.colloquium-figure:first-child:last-child > img {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: calc(100% - 1.5em);
+    width: 100%;
+    max-width: none;
+    max-height: none;
+    object-fit: contain;
+}
+.slide.img-tall-right .colloquium-grid > .col:last-child > figure.colloquium-figure:first-child:last-child > figcaption {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    text-align: center;
+}
+
 .valign-top.active { justify-content: flex-start; }
 .valign-center.active { justify-content: center; }
 .valign-bottom.active { justify-content: flex-end; }

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -2022,3 +2022,23 @@ class TestFragments:
         # blockquote (frag 1) wraps the <p> and bullets (frags 2, 3)
         assert 'data-fragment-count="3"' in html
         assert '<div class="fragment" data-fragment-index="1"><blockquote>' in html
+
+
+class TestImgTallRightUtility:
+    def test_theme_ships_img_tall_right_rules(self):
+        import pathlib
+        css = (pathlib.Path("colloquium/themes/default/theme.css")).read_text()
+        assert ".slide.img-tall-right" in css
+        assert "figure.colloquium-figure:first-child:last-child > figcaption" in css
+
+    def test_class_directive_reaches_slide_markup(self, tmp_path):
+        src = tmp_path / "deck.md"
+        src.write_text(
+            "---\ntitle: t\n---\n\n"
+            "<!-- columns: 45/55 -->\n<!-- class: img-tall-right -->\n## S\n\nText\n\n|||\n\n"
+            "![cap](x.png)\n"
+        )
+        out = tmp_path / "deck.html"
+        build_file(str(src), str(out))
+        html = out.read_text()
+        assert "img-tall-right" in html


### PR DESCRIPTION
## Summary
The captioned-figure fit pass scales the image to the full container height, so the caption always overflows below its cell — in practice landing on the slide footer (seen on rlhf-book lec13 rows/columns figure slides). It also unconditionally writes inline sizes, fighting any deck CSS that positions figures deliberately.

## Changes
- Reserve the caption's `offsetHeight` (plus the figure's flex gap) when computing the fit scale, so image + caption fit the cell together.
- Skip figures whose computed `position` is `absolute`, letting deck-level utilities (e.g. full-height column figures) own layout without `!important` wars.

Tests: 248 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)