### PR TITLE
Add print fallbacks for iframe embeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ One line per PR for easy copy into GitHub releases.
 
 ## [Unreleased]
 
+- Slide body links keep their screen link color in print/PDF export instead of flattening to text color ([#51](https://github.com/natolambert/colloquium/pull/51))
 - Print/PDF export renders iframe embeds as real page screenshots (captured at export time with headless Chromium) instead of Chromium's unreliable in-print frame rendering; a compact linked card is the fallback when a capture fails, and live HTML iframes are unchanged ([#51](https://github.com/natolambert/colloquium/pull/51))
 - Fix captioned-figure fitting scaling images to the full cell height so the caption overflowed onto the footer: the fit pass now reserves the caption's height, and skips absolutely positioned figures so author CSS can own layout. Captioned solo figures render slightly smaller (image + caption now fit the cell together) ([#50](https://github.com/natolambert/colloquium/pull/50))
 - Add opt-in `img-tall-right` slide class: on a columns slide, the right column's captioned figure runs from the slide top to the content bottom with the caption pinned beneath ([#50](https://github.com/natolambert/colloquium/pull/50))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,8 @@ One line per PR for easy copy into GitHub releases.
 
 ## [Unreleased]
 
-- PDF export no longer runs ghostscript compression by default (opt back in with `COLLOQUIUM_PDF_COMPRESS=1`): ghostscript 10.x writes broken ICC profiles that make images silently disappear in Apple's PDF viewers (Preview/QuickLook/Safari) while poppler-based viewers render them fine ([#51](https://github.com/natolambert/colloquium/pull/51))
-- Slide body links keep their screen link color in print/PDF export instead of flattening to text color ([#51](https://github.com/natolambert/colloquium/pull/51))
-- Print/PDF export renders iframe embeds as real page screenshots (captured at export time with headless Chromium) instead of Chromium's unreliable in-print frame rendering; a compact linked card is the fallback when a capture fails, and live HTML iframes are unchanged ([#51](https://github.com/natolambert/colloquium/pull/51))
-- Fix captioned-figure fitting scaling images to the full cell height so the caption overflowed onto the footer: the fit pass now reserves the caption's height, and skips absolutely positioned figures so author CSS can own layout. Captioned solo figures render slightly smaller (image + caption now fit the cell together) ([#50](https://github.com/natolambert/colloquium/pull/50))
-- Add opt-in `img-tall-right` slide class: on a columns slide, the right column's captioned figure runs from the slide top to the content bottom with the caption pinned beneath ([#50](https://github.com/natolambert/colloquium/pull/50))
+- Overhaul PDF export fidelity: iframe embeds print as real page screenshots captured at export time (compact linked card as offline fallback), slide links keep their screen color, and ghostscript compression is off by default (`COLLOQUIUM_PDF_COMPRESS=1` to opt in) since gs 10.x breaks ICC profiles and blanks images in Apple's PDF viewers ([#51](https://github.com/natolambert/colloquium/pull/51))
+- Fix captioned-figure fitting overflowing captions onto the footer (reserve caption height, skip absolutely positioned figures) and add the opt-in `img-tall-right` class for full-slide-height right-column figures ([#50](https://github.com/natolambert/colloquium/pull/50))
 
 ## [0.2.3] - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ One line per PR for easy copy into GitHub releases.
 
 ## [Unreleased]
 
+- Print/PDF export renders iframe embeds as stable linked cards (title + hostname link) instead of asking Chromium to snapshot remote frames, which produced blank or partial captures; live HTML iframes are unchanged ([#51](https://github.com/natolambert/colloquium/pull/51))
+
 ## [0.2.3] - 2026-08-03
 
 - Warn on stderr when a bibliography fails to parse (or pybtex is missing) instead of silently rendering every citation unresolved ([#48](https://github.com/natolambert/colloquium/pull/48))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ One line per PR for easy copy into GitHub releases.
 
 ## [Unreleased]
 
+- PDF export no longer runs ghostscript compression by default (opt back in with `COLLOQUIUM_PDF_COMPRESS=1`): ghostscript 10.x writes broken ICC profiles that make images silently disappear in Apple's PDF viewers (Preview/QuickLook/Safari) while poppler-based viewers render them fine ([#51](https://github.com/natolambert/colloquium/pull/51))
 - Slide body links keep their screen link color in print/PDF export instead of flattening to text color ([#51](https://github.com/natolambert/colloquium/pull/51))
 - Print/PDF export renders iframe embeds as real page screenshots (captured at export time with headless Chromium) instead of Chromium's unreliable in-print frame rendering; a compact linked card is the fallback when a capture fails, and live HTML iframes are unchanged ([#51](https://github.com/natolambert/colloquium/pull/51))
 - Fix captioned-figure fitting scaling images to the full cell height so the caption overflowed onto the footer: the fit pass now reserves the caption's height, and skips absolutely positioned figures so author CSS can own layout. Captioned solo figures render slightly smaller (image + caption now fit the cell together) ([#50](https://github.com/natolambert/colloquium/pull/50))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ One line per PR for easy copy into GitHub releases.
 
 ## [Unreleased]
 
-- Print/PDF export renders iframe embeds as stable linked cards (title + hostname link) instead of asking Chromium to snapshot remote frames, which produced blank or partial captures; live HTML iframes are unchanged ([#51](https://github.com/natolambert/colloquium/pull/51))
+- Print/PDF export renders iframe embeds as real page screenshots (captured at export time with headless Chromium) instead of Chromium's unreliable in-print frame rendering; a compact linked card is the fallback when a capture fails, and live HTML iframes are unchanged ([#51](https://github.com/natolambert/colloquium/pull/51))
 - Fix captioned-figure fitting scaling images to the full cell height so the caption overflowed onto the footer: the fit pass now reserves the caption's height, and skips absolutely positioned figures so author CSS can own layout. Captioned solo figures render slightly smaller (image + caption now fit the cell together) ([#50](https://github.com/natolambert/colloquium/pull/50))
 - Add opt-in `img-tall-right` slide class: on a columns slide, the right column's captioned figure runs from the slide top to the content bottom with the caption pinned beneath ([#50](https://github.com/natolambert/colloquium/pull/50))
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,3 +79,10 @@ colloquium/
     ├── theme.css     # Default theme
     └── presentation.js  # Navigation engine
 ```
+
+## Changelog
+
+Every PR must add exactly **one line** to `CHANGELOG.md` under `## [Unreleased]`,
+following the instructions at the top of that file (one line per PR, ending with
+the PR link). Multiple changes in one PR get folded into a single line — do not
+add one bullet per change.

--- a/colloquium/elements/iframe.py
+++ b/colloquium/elements/iframe.py
@@ -1,5 +1,6 @@
 import html as html_module
 import re
+from urllib.parse import urlsplit
 
 import yaml
 
@@ -69,6 +70,15 @@ def _width_css(width: str) -> str:
     return f"{width}px" if width.isdigit() else width
 
 
+def _print_link_label(src: str) -> str:
+    """Return a compact, human-readable label for the printed link."""
+    try:
+        hostname = urlsplit(src).hostname
+    except ValueError:
+        hostname = None
+    return hostname or "Open interactive content"
+
+
 def process(yaml_str: str) -> str:
     raw = html_module.unescape(yaml_str.strip())
     try:
@@ -105,6 +115,8 @@ def process(yaml_str: str) -> str:
     )
 
     src_attr = html_module.escape(src, quote=True)
+    print_title = title or "Interactive content"
+    print_link_label = html_module.escape(_print_link_label(src), quote=False)
     allow_attr = " allowfullscreen" if allow else ""
     keyboard_attr = str(preserve_keyboard).lower()
     scrolling_attr = (
@@ -117,5 +129,10 @@ def process(yaml_str: str) -> str:
         f'data-colloquium-preserve-keyboard="{keyboard_attr}" '
         f'width="{html_module.escape(width, quote=True)}" height="{height}" '
         f'frameborder="{frameborder}"{scrolling_attr}{allow_attr} '
-        f'style="{html_module.escape(style, quote=True)}"></iframe></div>'
+        f'style="{html_module.escape(style, quote=True)}"></iframe>'
+        f'<div class="colloquium-iframe-print-fallback">'
+        f'<span class="colloquium-iframe-print-label">Interactive content</span>'
+        f'<strong class="colloquium-iframe-print-title">{print_title}</strong>'
+        f'<a class="colloquium-iframe-print-link" href="{src_attr}">{print_link_label}</a>'
+        f'</div></div>'
     )

--- a/colloquium/elements/iframe.py
+++ b/colloquium/elements/iframe.py
@@ -131,7 +131,6 @@ def process(yaml_str: str) -> str:
         f'frameborder="{frameborder}"{scrolling_attr}{allow_attr} '
         f'style="{html_module.escape(style, quote=True)}"></iframe>'
         f'<div class="colloquium-iframe-print-fallback">'
-        f'<span class="colloquium-iframe-print-label">Interactive content</span>'
         f'<strong class="colloquium-iframe-print-title">{print_title}</strong>'
         f'<a class="colloquium-iframe-print-link" href="{src_attr}">{print_link_label}</a>'
         f'</div></div>'

--- a/colloquium/export.py
+++ b/colloquium/export.py
@@ -337,7 +337,17 @@ def capture_slides(
 
 
 def _compress_pdf(pdf_path: str) -> None:
-    """Compress PDF with ghostscript if available."""
+    """Compress PDF with ghostscript, only when explicitly requested.
+
+    Opt-in via COLLOQUIUM_PDF_COMPRESS=1. Ghostscript 10.x rewrites the
+    ICC color profiles in Chromium's PDFs into zero-length streams that
+    Apple's PDF renderer (Preview, Quicklook, Safari) rejects — images
+    silently disappear there while poppler-based viewers still render
+    them. Correct output beats smaller output, so compression is off by
+    default.
+    """
+    if os.environ.get("COLLOQUIUM_PDF_COMPRESS") != "1":
+        return
     gs = shutil.which("gs")
     if not gs:
         return

--- a/colloquium/export.py
+++ b/colloquium/export.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import base64
+import html as html_module
 import http.server
 import os
+import re
 import shutil
 import socketserver
 import subprocess
@@ -91,6 +94,89 @@ def _serve_html_for_export(html_path: str):
             thread.join(timeout=2)
 
 
+_IFRAME_TAG_RE = re.compile(r'<iframe class="colloquium-iframe" src="([^"]+)"[^>]*></iframe>')
+
+
+def _capture_page_snapshot(browser: str, url: str, out_path: str) -> bool:
+    """Screenshot a URL with headless Chromium; True if a usable PNG landed."""
+    cmd = [
+        browser,
+        "--headless=new",
+        "--disable-gpu",
+        "--hide-scrollbars",
+        "--force-device-scale-factor=2",
+        f"--screenshot={out_path}",
+        "--window-size=1280,720",
+        f"--virtual-time-budget={_pdf_time_budget_ms()}",
+        url,
+    ]
+    try:
+        subprocess.run(cmd, capture_output=True, timeout=120, check=True)
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+        return False
+    out = Path(out_path)
+    return out.exists() and out.stat().st_size > 1024
+
+
+def _inject_iframe_snapshots(html: str, browser: str) -> str:
+    """Insert real page screenshots after each iframe for print output.
+
+    Chromium's print-to-pdf renders remote frames unreliably (blank or
+    half-loaded depending on headers and timing). Instead, screenshot each
+    iframe's URL as a normal page — exactly what the live embed shows — and
+    print that image. The linked-card fallback that follows each iframe in
+    the markup is suppressed by CSS when a snapshot is present, so it only
+    appears if the capture fails (e.g. offline).
+    """
+    snapshots: dict[str, str | None] = {}
+
+    def replace(match: re.Match) -> str:
+        escaped_src = match.group(1)
+        url = html_module.unescape(escaped_src)
+        if url not in snapshots:
+            with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
+                tmp_path = tmp.name
+            try:
+                if _capture_page_snapshot(browser, url, tmp_path):
+                    data = Path(tmp_path).read_bytes()
+                    snapshots[url] = base64.b64encode(data).decode("ascii")
+                else:
+                    snapshots[url] = None
+            finally:
+                Path(tmp_path).unlink(missing_ok=True)
+        encoded = snapshots[url]
+        if encoded is None:
+            return match.group(0)
+        return (
+            match.group(0)
+            + '<img class="colloquium-iframe-print-snapshot" '
+            + f'src="data:image/png;base64,{encoded}" alt="" />'
+        )
+
+    return _IFRAME_TAG_RE.sub(replace, html)
+
+
+@contextmanager
+def _print_ready_html(html_path: str, browser: str):
+    """Yield a path to print, with iframe snapshots injected when present.
+
+    The temp file lives next to the original so relative asset paths keep
+    resolving, and is removed afterwards.
+    """
+    html_file = Path(html_path)
+    html = html_file.read_text(encoding="utf-8")
+    if not _IFRAME_TAG_RE.search(html):
+        yield html_path
+        return
+    injected = _inject_iframe_snapshots(html, browser)
+    tmp = html_file.with_name(f".{html_file.stem}-print{html_file.suffix}")
+    tmp.write_text(injected, encoding="utf-8")
+    try:
+        yield str(tmp)
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
 def _export_pdf_from_html(html_path: str, output_path: str) -> str | None:
     """Export an existing HTML deck to PDF using a system browser."""
     browser = _find_browser()
@@ -102,7 +188,9 @@ def _export_pdf_from_html(html_path: str, output_path: str) -> str | None:
 
     # Use Chromium's headless print-to-pdf
     # 10in x 5.625in = 16:9 landscape, matching @page size in print CSS
-    with _serve_html_for_export(html_path) as html_url:
+    with _print_ready_html(html_path, browser) as print_path, _serve_html_for_export(
+        print_path
+    ) as html_url:
         cmd = [
             browser,
             "--headless",

--- a/colloquium/export.py
+++ b/colloquium/export.py
@@ -98,22 +98,44 @@ _IFRAME_TAG_RE = re.compile(r'<iframe class="colloquium-iframe" src="([^"]+)"[^>
 
 
 def _capture_page_snapshot(browser: str, url: str, out_path: str) -> bool:
-    """Screenshot a URL with headless Chromium; True if a usable PNG landed."""
-    cmd = [
-        browser,
-        "--headless=new",
-        "--disable-gpu",
-        "--hide-scrollbars",
-        "--force-device-scale-factor=2",
-        f"--screenshot={out_path}",
-        "--window-size=1280,720",
-        f"--virtual-time-budget={_pdf_time_budget_ms()}",
-        url,
-    ]
-    try:
-        subprocess.run(cmd, capture_output=True, timeout=120, check=True)
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
-        return False
+    """Screenshot a URL as an embedded frame; True if a usable PNG landed.
+
+    The URL is loaded inside an iframe on a minimal wrapper page rather than
+    navigated to directly: embed endpoints (e.g. YouTube's) only initialize
+    in an embedding context and refuse top-level navigation.
+    """
+    wrapper = (
+        "<!doctype html><html><head><meta charset='utf-8'></head>"
+        "<body style='margin:0;background:#fff'>"
+        f"<iframe src=\"{html_module.escape(url, quote=True)}\" "
+        "style='display:block;width:1280px;height:720px;border:none' "
+        "allowfullscreen></iframe></body></html>"
+    )
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        wrapper_path = Path(tmp_dir) / "colloquium-iframe-capture.html"
+        wrapper_path.write_text(wrapper, encoding="utf-8")
+        # Serve over loopback HTTP: embed providers (YouTube among them)
+        # require a real referrer/origin and reject frames on file:// pages.
+        with _serve_html_for_export(str(wrapper_path)) as wrapper_url:
+            cmd = [
+                browser,
+                "--headless=new",
+                "--disable-gpu",
+                "--hide-scrollbars",
+                "--force-device-scale-factor=2",
+                f"--screenshot={out_path}",
+                "--window-size=1280,720",
+                f"--virtual-time-budget={_pdf_time_budget_ms()}",
+                wrapper_url,
+            ]
+            try:
+                subprocess.run(cmd, capture_output=True, timeout=120, check=True)
+            except (
+                subprocess.CalledProcessError,
+                subprocess.TimeoutExpired,
+                FileNotFoundError,
+            ):
+                return False
     out = Path(out_path)
     return out.exists() and out.stat().st_size > 1024
 

--- a/colloquium/export.py
+++ b/colloquium/export.py
@@ -128,16 +128,23 @@ def _capture_page_snapshot(browser: str, url: str, out_path: str) -> bool:
                 f"--virtual-time-budget={_pdf_time_budget_ms()}",
                 wrapper_url,
             ]
-            try:
-                subprocess.run(cmd, capture_output=True, timeout=120, check=True)
-            except (
-                subprocess.CalledProcessError,
-                subprocess.TimeoutExpired,
-                FileNotFoundError,
-            ):
-                return False
-    out = Path(out_path)
-    return out.exists() and out.stat().st_size > 1024
+            # A capture can complete as a solid blank frame when virtual time
+            # outruns the remote load. A uniform PNG compresses to a few KB
+            # while real content is far larger, so treat tiny files as
+            # failures and give the load timing a second chance.
+            for _attempt in range(2):
+                try:
+                    subprocess.run(cmd, capture_output=True, timeout=120, check=True)
+                except (
+                    subprocess.CalledProcessError,
+                    subprocess.TimeoutExpired,
+                    FileNotFoundError,
+                ):
+                    return False
+                out = Path(out_path)
+                if out.exists() and out.stat().st_size > 16384:
+                    return True
+    return False
 
 
 def _inject_iframe_snapshots(html: str, browser: str) -> str:

--- a/colloquium/themes/default/theme.css
+++ b/colloquium/themes/default/theme.css
@@ -209,8 +209,11 @@ html, body {
 }
 
 /* Remote iframe contents are interactive on screen but unreliable in browser
-   print output. The deterministic fallback is enabled only by print styles. */
-.colloquium-iframe-print-fallback {
+   print output. Export captures real page snapshots for print; the linked
+   card is a fallback when a snapshot could not be captured. Both are
+   print-only. */
+.colloquium-iframe-print-fallback,
+.colloquium-iframe-print-snapshot {
     display: none;
 }
 
@@ -1776,6 +1779,19 @@ body:hover .colloquium-present {
         display: none !important;
     }
 
+    .colloquium-iframe-print-snapshot {
+        display: block !important;
+        width: 100%;
+        height: auto;
+        border: 1px solid var(--colloquium-border);
+        border-radius: 6px;
+    }
+
+    /* A captured snapshot supersedes the linked card. */
+    .colloquium-iframe-print-snapshot + .colloquium-iframe-print-fallback {
+        display: none !important;
+    }
+
     .colloquium-iframe-print-fallback {
         display: flex !important;
         flex-direction: column;
@@ -1795,15 +1811,6 @@ body:hover .colloquium-present {
     .colloquium-iframe-container {
         min-height: 0 !important;
         height: auto !important;
-    }
-
-    .colloquium-iframe-print-label {
-        margin-bottom: 0.35em;
-        color: var(--colloquium-muted);
-        font-size: 0.65em;
-        font-weight: 600;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
     }
 
     .colloquium-iframe-print-title {

--- a/colloquium/themes/default/theme.css
+++ b/colloquium/themes/default/theme.css
@@ -1772,6 +1772,12 @@ body:hover .colloquium-present {
         text-decoration: underline;
     }
 
+    /* Content links keep their screen color in print so readers can see
+       which text is a URL; chrome/footer links stay muted via inherit. */
+    .slide a {
+        color: var(--colloquium-link) !important;
+    }
+
     /* Never ask Chromium to snapshot a remote frame into the PDF. Depending on
        the site's headers and load timing, that produces a blank or partial
        frame. Preserve the live iframe in HTML and print a stable linked card. */

--- a/colloquium/themes/default/theme.css
+++ b/colloquium/themes/default/theme.css
@@ -208,6 +208,12 @@ html, body {
     max-width: 100%;
 }
 
+/* Remote iframe contents are interactive on screen but unreliable in browser
+   print output. The deterministic fallback is enabled only by print styles. */
+.colloquium-iframe-print-fallback {
+    display: none;
+}
+
 .align-center .slide-content > .colloquium-iframe-container {
     margin-left: auto;
     margin-right: auto;
@@ -1710,6 +1716,51 @@ body:hover .colloquium-present {
     a {
         color: inherit !important;
         text-decoration: underline;
+    }
+
+    /* Never ask Chromium to snapshot a remote frame into the PDF. Depending on
+       the site's headers and load timing, that produces a blank or partial
+       frame. Preserve the live iframe in HTML and print a stable linked card. */
+    .colloquium-iframe {
+        display: none !important;
+    }
+
+    .colloquium-iframe-print-fallback {
+        display: flex !important;
+        flex-direction: column;
+        align-items: flex-start;
+        justify-content: center;
+        width: 100%;
+        min-height: inherit;
+        padding: 1.2em 1.35em;
+        border: 2px solid var(--colloquium-border);
+        border-left: 8px solid var(--colloquium-accent);
+        border-radius: 10px;
+        background: var(--colloquium-bg);
+        text-align: left;
+    }
+
+    .colloquium-iframe-print-label {
+        margin-bottom: 0.35em;
+        color: var(--colloquium-muted);
+        font-size: 0.65em;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+    }
+
+    .colloquium-iframe-print-title {
+        margin-bottom: 0.55em;
+        color: var(--colloquium-heading);
+        font-family: var(--colloquium-font-heading);
+        font-size: 1.15em;
+        line-height: 1.25;
+    }
+
+    .slide a.colloquium-iframe-print-link {
+        color: var(--colloquium-link) !important;
+        font-size: 0.8em;
+        overflow-wrap: anywhere;
     }
 
     .slide a.colloquium-cite,

--- a/tests/elements/test_iframe.py
+++ b/tests/elements/test_iframe.py
@@ -14,6 +14,9 @@ def test_iframe_renders_with_required_src():
     assert 'loading="eager"' in out  # default
     assert 'allowfullscreen' in out
     assert 'data-colloquium-preserve-keyboard="true"' in out
+    assert 'class="colloquium-iframe-print-fallback"' in out
+    assert 'class="colloquium-iframe-print-title">Interactive content</strong>' in out
+    assert 'class="colloquium-iframe-print-link" href="https://example.com/embed.html">example.com</a>' in out
 
 
 def test_iframe_renders_optional_fields():
@@ -36,6 +39,7 @@ def test_iframe_renders_optional_fields():
     assert 'loading="lazy"' in out
     assert 'allowfullscreen' not in out
     assert 'data-colloquium-preserve-keyboard="false"' in out
+    assert 'class="colloquium-iframe-print-title">Demo Frame</strong>' in out
 
 
 def test_iframe_invalid_yaml():
@@ -70,6 +74,14 @@ def test_iframe_sanitizes_src_and_title():
     )
     assert 'src="https://example.com/?q=&quot;x&quot;&amp;k=&lt;tag&gt;"' in out
     assert 'title="&lt;unsafe&gt;"' in out
+    assert 'class="colloquium-iframe-print-title">&lt;unsafe&gt;</strong>' in out
+    assert 'href="https://example.com/?q=&quot;x&quot;&amp;k=&lt;tag&gt;"' in out
+
+
+def test_iframe_print_fallback_labels_relative_sources():
+    out = _render_iframe_block("src: demos/live.html\ntitle: Local demo")
+    assert 'class="colloquium-iframe-print-title">Local demo</strong>' in out
+    assert '>Open interactive content</a>' in out
 
 
 def test_iframe_height_falls_back_to_default_for_invalid_values():

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -162,7 +162,10 @@ class TestBuildDeck:
 
         assert '<iframe class="colloquium-iframe"' in html
         assert '<div class="colloquium-iframe-print-fallback">' in html
-        assert ".colloquium-iframe-print-fallback {\n    display: none;" in html
+        assert (
+            ".colloquium-iframe-print-fallback,\n"
+            ".colloquium-iframe-print-snapshot {\n    display: none;"
+        ) in html
         print_css = html[html.index("@media print") :]
         assert ".colloquium-iframe {\n        display: none !important;" in print_css
         assert ".colloquium-iframe-print-fallback {\n        display: flex !important;" in print_css

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -147,6 +147,26 @@ class TestBuildDeck:
         assert ".slide .katex-display {" in html
         assert "overflow: visible !important;" in html
 
+    def test_print_css_swaps_live_iframes_for_linked_fallbacks(self):
+        deck = Deck(title="Test")
+        deck.add_slide(
+            title="Embed",
+            content=(
+                "```iframe\n"
+                "src: https://example.com/embed.html\n"
+                "title: Interactive demo\n"
+                "```"
+            ),
+        )
+        html = build_deck(deck)
+
+        assert '<iframe class="colloquium-iframe"' in html
+        assert '<div class="colloquium-iframe-print-fallback">' in html
+        assert ".colloquium-iframe-print-fallback {\n    display: none;" in html
+        print_css = html[html.index("@media print") :]
+        assert ".colloquium-iframe {\n        display: none !important;" in print_css
+        assert ".colloquium-iframe-print-fallback {\n        display: flex !important;" in print_css
+
     def test_align_center_centers_standalone_images(self):
         deck = Deck(title="Test")
         deck.add_slide(title="Centered", content="![Alt](image.png)", classes=["align-center"])

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -36,3 +36,39 @@ data:
 
         assert Path(result).exists()
         assert Path(result).suffix == ".pptx"
+
+
+class TestIframePrintSnapshots:
+    def test_injects_snapshot_after_iframe_and_before_fallback(self, monkeypatch, tmp_path):
+        from colloquium import export as export_module
+
+        def fake_capture(browser, url, out_path):
+            import pathlib
+            pathlib.Path(out_path).write_bytes(b"\x89PNG" + b"0" * 2048)
+            return True
+
+        monkeypatch.setattr(export_module, "_capture_page_snapshot", fake_capture)
+        html = (
+            '<iframe class="colloquium-iframe" src="https://example.com/a?x=1&amp;y=2" '
+            'width="100%" height="300" frameborder="0" style="border:none"></iframe>'
+            '<div class="colloquium-iframe-print-fallback">card</div>'
+        )
+        out = export_module._inject_iframe_snapshots(html, browser="chrome")
+        assert 'colloquium-iframe-print-snapshot' in out
+        snap_at = out.index("colloquium-iframe-print-snapshot")
+        assert out.index("</iframe>") < snap_at < out.index("colloquium-iframe-print-fallback")
+        assert "data:image/png;base64," in out
+
+    def test_failed_capture_leaves_markup_unchanged(self, monkeypatch):
+        from colloquium import export as export_module
+
+        monkeypatch.setattr(
+            export_module, "_capture_page_snapshot", lambda *a, **k: False
+        )
+        html = (
+            '<iframe class="colloquium-iframe" src="https://example.com/a" '
+            'width="100%" height="300" frameborder="0" style="x"></iframe>'
+            '<div class="colloquium-iframe-print-fallback">card</div>'
+        )
+        out = export_module._inject_iframe_snapshots(html, browser="chrome")
+        assert out == html

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -44,7 +44,7 @@ class TestIframePrintSnapshots:
 
         def fake_capture(browser, url, out_path):
             import pathlib
-            pathlib.Path(out_path).write_bytes(b"\x89PNG" + b"0" * 2048)
+            pathlib.Path(out_path).write_bytes(b"\x89PNG" + b"0" * 32768)
             return True
 
         monkeypatch.setattr(export_module, "_capture_page_snapshot", fake_capture)


### PR DESCRIPTION
## Summary
- preserve live iframe markup and behavior in HTML
- add a hidden linked fallback card for print/PDF export
- hide unreliable remote iframe snapshots only under `@media print`

## Validation
- `uv run --extra dev pytest` — 249 passed, 1 skipped
- exported RLHF Book Lecture 10 — 33 pages
- visually inspected page 6: both embeds fit as linked cards
- verified generated HTML retains both original iframe `src`, `title`, and `style` values